### PR TITLE
ml-kem v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "ml-kem"
-version = "0.1.0-alpha"
+version = "0.1.0"
 dependencies = [
  "criterion",
  "hex",

--- a/ml-kem/CHANGELOG.md
+++ b/ml-kem/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.0 (2024-04-12)
+
+- Initial release

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Module-Lattice-Based Key-Encapsulation Mechanism Standard
 (formerly known as Kyber) as described in the FIPS 203 Initial Public Draft
 """
-version = "0.1.0-alpha"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0 OR MIT"

--- a/ml-kem/README.md
+++ b/ml-kem/README.md
@@ -12,6 +12,23 @@ Pure Rust implementation of the Module-Lattice-Based Key-Encapsulation Mechanism
 
 [Documentation][docs-link]
 
+## About
+
+ML-KEM is a cutting-edge post-quantum secure key encapsulation mechanism (KEM). KEMs play a vital
+role in modern cryptographic systems by securely exchanging keys between parties, ensuring
+confidential communication over insecure channels.
+
+Originally developed as Kyber, ML-KEM inherits the foundation of its predecessor while introducing
+refinements and optimizations to enhance its security and efficiency. ML-KEM and Kyber are
+intimately related, with ML-KEM representing a refined and evolved version of the original Kyber
+algorithm. While Kyber pioneered lattice-based cryptography and provided a reliable framework for
+secure key exchange, ML-KEM builds upon this foundation, incorporating advancements in
+cryptographic research and addressing potential vulnerabilities.
+
+In summary, ML-KEM stands at the forefront of post-quantum cryptography, offering enhanced security
+and efficiency in key encapsulation mechanisms to safeguard sensitive communications in an era where
+quantum computers potentially pose a looming threat.
+
 ## ⚠️ Security Warning
 
 The implementation contained in this crate has never been independently audited!


### PR DESCRIPTION
Initial release.

Only change from `v0.1.0-alpha` is bumping `hybrid-array` to `v0.2.0-rc.8`.