### PR TITLE
Add KEM providers for common ECDH schemes

### DIFF
--- a/.github/workflows/dhkem.yml
+++ b/.github/workflows/dhkem.yml
@@ -1,0 +1,68 @@
+name: dhkem
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/dhkem.yml"
+      - "dhkem/**"
+      - "Cargo.*"
+  push:
+    branches: master
+
+defaults:
+  run:
+    working-directory: dhkem
+
+env:
+  RUSTFLAGS: "-Dwarnings"
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  set-msrv:
+    uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
+    with:
+      msrv: 1.74.0
+
+  minimal-versions:
+    # temporarily disabled as requested by Tony (https://github.com/RustCrypto/KEMs/pull/15#pullrequestreview-2006378802)
+    if: false
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+      working-directory: ${{ github.workflow }}
+
+  test:
+    needs: set-msrv
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - ${{needs.set-msrv.outputs.msrv}}
+          - stable
+    steps:
+      - uses: actions/checkout@v4
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo test --no-default-features
+      - run: cargo test
+      - run: cargo test --all-features
+
+  cross:
+    needs: set-msrv
+    strategy:
+      matrix:
+        include:
+          - target: powerpc-unknown-linux-gnu
+            rust: ${{needs.set-msrv.outputs.msrv}}
+          - target: powerpc-unknown-linux-gnu
+            rust: stable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - uses: RustCrypto/actions/cross-install@master
+      - run: cross test --release --target ${{ matrix.target }} --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,7 @@ dependencies = [
  "rand_core",
  "sm2",
  "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "belt-block"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
+
+[[package]]
+name = "belt-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc405b3b8472f6e019aedf942fdee9516a0546d12e053d3744416e8f21ddb8a"
+dependencies = [
+ "belt-block",
+ "digest",
+]
+
+[[package]]
+name = "bign256"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a060e09443574e5518c7eced1ef6ff33496be5aee6dc101f99102039d3922eff"
+dependencies = [
+ "belt-hash",
+ "crypto-bigint",
+ "elliptic-curve",
+ "primeorder",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +151,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +233,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,13 +255,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "dhkem"
+version = "0.1.0"
+dependencies = [
+ "bign256",
+ "elliptic-curve",
+ "k256",
+ "kem",
+ "p192",
+ "p224",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core",
+ "sm2",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -211,6 +343,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +387,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -229,6 +399,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -258,6 +439,24 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "hybrid-array"
@@ -301,6 +500,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -376,6 +589,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "p192"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0533bc6c238f2669aab8db75ae52879dc74e88d6bd3685bd4022a00fa85cd2"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sec1",
+]
+
+[[package]]
+name = "p224"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30c06436d66652bc2f01ade021592c80a2aad401570a18aa18b82e440d2b9aa1"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core",
+ "sha2",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "platforms"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
+
+[[package]]
 name = "plotters"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +708,15 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -507,6 +816,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +848,26 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
@@ -553,6 +901,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +920,54 @@ dependencies = [
  "digest",
  "keccak",
 ]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
+name = "sm2"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98b22092ef242a118f03ee41dc46b2720c0ca076f544116dbc915cacf532cfaa"
+dependencies = [
+ "elliptic-curve",
+ "primeorder",
+ "rfc6979",
+ "signature",
+ "sm3",
+]
+
+[[package]]
+name = "sm3"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb9a3b702d0a7e33bc4d85a14456633d2b165c2ad839c5fd9a8417c1ab15860"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -779,7 +1186,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,8 @@ version = "0.1.0"
 dependencies = [
  "bign256",
  "elliptic-curve",
+ "hex-literal",
+ "hkdf",
  "k256",
  "kem",
  "p192",
@@ -307,6 +309,7 @@ dependencies = [
  "p521",
  "rand",
  "rand_core",
+ "sha2",
  "sm2",
  "x25519-dalek",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "p256",
  "p384",
  "p521",
+ "rand",
  "rand_core",
  "sm2",
  "x25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "dhkem",
     "ml-kem",
 ]
 

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "dhkem"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+kem = "0.3.0-pre.0"
+rand_core = "0.6.4"
+x25519 = { version = "2.0.1", package = "x25519-dalek", optional = true }
+elliptic-curve = { version = "0.13.8", optional = true }
+bign256 = { version = "0.13.1", optional = true }
+k256 = { version = "0.13.3", optional = true }
+p192 = { version = "0.13.0", optional = true }
+p224 = { version = "0.13.2", optional = true }
+p256 = { version = "0.13.2", optional = true }
+p384 = { version = "0.13.0", optional = true }
+p521 = { version = "0.13.3", optional = true }
+sm2 = { version = "0.13.3", optional = true }
+
+[features]
+arithmetic = ["dep:elliptic-curve", "elliptic-curve/ecdh"]
+x25519 = ["dep:x25519", "x25519/reusable_secrets"]
+bign256 = ["dep:bign256", "arithmetic"]
+k256 = ["dep:k256", "arithmetic"]
+p192 = ["dep:p192", "arithmetic"]
+p224 = ["dep:p224", "arithmetic"]
+p256 = ["dep:p256", "arithmetic"]
+p384 = ["dep:p384", "arithmetic"]
+p521 = ["dep:p521", "arithmetic"]
+sm2 = ["dep:sm2", "arithmetic"]

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "dhkem"
+description = """
+Key Encapsulation Mechanism (KEM) adapters for Elliptic Curve Diffie Hellman (ECDH) protocols
+"""
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.74"
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/RustCrypto/KEMs/tree/master/dhkem"
+categories = ["cryptography"]
+keywords = ["crypto", "ecdh", "ecc"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -44,6 +44,9 @@ zeroize = ["dep:zeroize"]
 
 [dev-dependencies]
 rand = "0.8.5"
+hex-literal = "0.4.1"
+hkdf = "0.12.4"
+sha2 = "0.10.8"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -26,8 +26,10 @@ p256 = { version = "0.13.2", optional = true }
 p384 = { version = "0.13.0", optional = true }
 p521 = { version = "0.13.3", optional = true }
 sm2 = { version = "0.13.3", optional = true }
+zeroize = { version = "1.7.0", optional = true }
 
 [features]
+default = ["zeroize"]
 arithmetic = ["dep:elliptic-curve", "elliptic-curve/ecdh"]
 x25519 = ["dep:x25519", "x25519/reusable_secrets"]
 bign256 = ["dep:bign256", "arithmetic"]
@@ -38,6 +40,11 @@ p256 = ["dep:p256", "arithmetic"]
 p384 = ["dep:p384", "arithmetic"]
 p521 = ["dep:p521", "arithmetic"]
 sm2 = ["dep:sm2", "arithmetic"]
+zeroize = ["dep:zeroize"]
 
 [dev-dependencies]
 rand = "0.8.5"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -38,3 +38,6 @@ p256 = ["dep:p256", "arithmetic"]
 p384 = ["dep:p384", "arithmetic"]
 p521 = ["dep:p521", "arithmetic"]
 sm2 = ["dep:sm2", "arithmetic"]
+
+[dev-dependencies]
+rand = "0.8.5"

--- a/dhkem/src/arithmetic.rs
+++ b/dhkem/src/arithmetic.rs
@@ -57,13 +57,3 @@ where
         (Decapsulator(sk), Encapsulator(pk))
     }
 }
-
-#[cfg(test)]
-impl<C> crate::SecretBytes for SharedSecret<C>
-where
-    C: CurveArithmetic,
-{
-    fn as_slice(&self) -> &[u8] {
-        self.raw_secret_bytes().as_slice()
-    }
-}

--- a/dhkem/src/arithmetic.rs
+++ b/dhkem/src/arithmetic.rs
@@ -62,3 +62,13 @@ where
         (DhKemProxy(sk), DhKemProxy(pk))
     }
 }
+
+#[cfg(test)]
+impl<C> crate::SecretBytes for DhKemProxy<SharedSecret<C>>
+where
+    C: CurveArithmetic,
+{
+    fn as_slice(&self) -> &[u8] {
+        self.0.raw_secret_bytes().as_slice()
+    }
+}

--- a/dhkem/src/arithmetic.rs
+++ b/dhkem/src/arithmetic.rs
@@ -1,0 +1,64 @@
+use crate::{DhKem, DhKemProxy};
+use elliptic_curve::ecdh::{EphemeralSecret, SharedSecret};
+use elliptic_curve::{CurveArithmetic, PublicKey};
+use kem::{Decapsulate, Encapsulate};
+use rand_core::CryptoRngCore;
+use std::marker::PhantomData;
+
+pub struct ArithmeticKem<C: CurveArithmetic>(PhantomData<C>);
+
+impl<C> Encapsulate<DhKemProxy<PublicKey<C>>, DhKemProxy<SharedSecret<C>>>
+    for DhKemProxy<PublicKey<C>>
+where
+    C: CurveArithmetic,
+{
+    type Error = ();
+
+    fn encapsulate(
+        &self,
+        rng: &mut impl CryptoRngCore,
+    ) -> Result<(DhKemProxy<PublicKey<C>>, DhKemProxy<SharedSecret<C>>), Self::Error> {
+        // ECDH encapsulation involves creating a new ephemeral key pair and then doing DH
+        let sk = EphemeralSecret::random(rng);
+        let pk = sk.public_key();
+        let ss = sk.diffie_hellman(&self.0);
+
+        Ok((DhKemProxy(pk), DhKemProxy(ss)))
+    }
+}
+
+impl<C> Decapsulate<DhKemProxy<PublicKey<C>>, DhKemProxy<SharedSecret<C>>>
+    for DhKemProxy<EphemeralSecret<C>>
+where
+    C: CurveArithmetic,
+{
+    type Error = ();
+
+    fn decapsulate(
+        &self,
+        encapsulated_key: &DhKemProxy<PublicKey<C>>,
+    ) -> Result<DhKemProxy<SharedSecret<C>>, Self::Error> {
+        let ss = self.0.diffie_hellman(&encapsulated_key.0);
+
+        Ok(DhKemProxy(ss))
+    }
+}
+
+impl<C> DhKem for ArithmeticKem<C>
+where
+    C: CurveArithmetic,
+{
+    type DecapsulatingKey = DhKemProxy<EphemeralSecret<C>>;
+    type EncapsulatingKey = DhKemProxy<PublicKey<C>>;
+    type EncapsulatedKey = DhKemProxy<PublicKey<C>>;
+    type SharedSecret = DhKemProxy<SharedSecret<C>>;
+
+    fn random_keypair(
+        rng: &mut impl CryptoRngCore,
+    ) -> (Self::DecapsulatingKey, Self::EncapsulatingKey) {
+        let sk = EphemeralSecret::random(rng);
+        let pk = PublicKey::from(&sk);
+
+        (DhKemProxy(sk), DhKemProxy(pk))
+    }
+}

--- a/dhkem/src/arithmetic.rs
+++ b/dhkem/src/arithmetic.rs
@@ -1,5 +1,5 @@
-use crate::{Decapsulator, DhKem, EncapsulatedKey, Encapsulator, SharedSecret};
-use elliptic_curve::ecdh::{EphemeralSecret, SharedSecret as EcdhSecret};
+use crate::{Decapsulator, DhKem, Encapsulator};
+use elliptic_curve::ecdh::{EphemeralSecret, SharedSecret};
 use elliptic_curve::{CurveArithmetic, PublicKey};
 use kem::{Decapsulate, Encapsulate};
 use rand_core::CryptoRngCore;
@@ -7,8 +7,7 @@ use std::marker::PhantomData;
 
 pub struct ArithmeticKem<C: CurveArithmetic>(PhantomData<C>);
 
-impl<C> Encapsulate<EncapsulatedKey<PublicKey<C>>, SharedSecret<EcdhSecret<C>>>
-    for Encapsulator<PublicKey<C>>
+impl<C> Encapsulate<PublicKey<C>, SharedSecret<C>> for Encapsulator<PublicKey<C>>
 where
     C: CurveArithmetic,
 {
@@ -17,30 +16,26 @@ where
     fn encapsulate(
         &self,
         rng: &mut impl CryptoRngCore,
-    ) -> Result<(EncapsulatedKey<PublicKey<C>>, SharedSecret<EcdhSecret<C>>), Self::Error> {
+    ) -> Result<(PublicKey<C>, SharedSecret<C>), Self::Error> {
         // ECDH encapsulation involves creating a new ephemeral key pair and then doing DH
         let sk = EphemeralSecret::random(rng);
         let pk = sk.public_key();
         let ss = sk.diffie_hellman(&self.0);
 
-        Ok((EncapsulatedKey(pk), SharedSecret(ss)))
+        Ok((pk, ss))
     }
 }
 
-impl<C> Decapsulate<EncapsulatedKey<PublicKey<C>>, SharedSecret<EcdhSecret<C>>>
-    for Decapsulator<EphemeralSecret<C>>
+impl<C> Decapsulate<PublicKey<C>, SharedSecret<C>> for Decapsulator<EphemeralSecret<C>>
 where
     C: CurveArithmetic,
 {
     type Error = ();
 
-    fn decapsulate(
-        &self,
-        encapsulated_key: &EncapsulatedKey<PublicKey<C>>,
-    ) -> Result<SharedSecret<EcdhSecret<C>>, Self::Error> {
-        let ss = self.0.diffie_hellman(&encapsulated_key.0);
+    fn decapsulate(&self, encapsulated_key: &PublicKey<C>) -> Result<SharedSecret<C>, Self::Error> {
+        let ss = self.0.diffie_hellman(&encapsulated_key);
 
-        Ok(SharedSecret(ss))
+        Ok(ss)
     }
 }
 
@@ -50,8 +45,8 @@ where
 {
     type DecapsulatingKey = Decapsulator<EphemeralSecret<C>>;
     type EncapsulatingKey = Encapsulator<PublicKey<C>>;
-    type EncapsulatedKey = EncapsulatedKey<PublicKey<C>>;
-    type SharedSecret = SharedSecret<EcdhSecret<C>>;
+    type EncapsulatedKey = PublicKey<C>;
+    type SharedSecret = SharedSecret<C>;
 
     fn random_keypair(
         rng: &mut impl CryptoRngCore,
@@ -64,11 +59,11 @@ where
 }
 
 #[cfg(test)]
-impl<C> crate::SecretBytes for SharedSecret<EcdhSecret<C>>
+impl<C> crate::SecretBytes for SharedSecret<C>
 where
     C: CurveArithmetic,
 {
     fn as_slice(&self) -> &[u8] {
-        self.0.raw_secret_bytes().as_slice()
+        self.raw_secret_bytes().as_slice()
     }
 }

--- a/dhkem/src/arithmetic.rs
+++ b/dhkem/src/arithmetic.rs
@@ -1,4 +1,4 @@
-use crate::{DhDecapsulator, DhKem, DhEncapsulator};
+use crate::{DhDecapsulator, DhEncapsulator, DhKem};
 use elliptic_curve::ecdh::{EphemeralSecret, SharedSecret};
 use elliptic_curve::{CurveArithmetic, PublicKey};
 use kem::{Decapsulate, Encapsulate};

--- a/dhkem/src/arithmetic.rs
+++ b/dhkem/src/arithmetic.rs
@@ -1,4 +1,4 @@
-use crate::{Decapsulator, DhKem, Encapsulator};
+use crate::{DhDecapsulator, DhKem, DhEncapsulator};
 use elliptic_curve::ecdh::{EphemeralSecret, SharedSecret};
 use elliptic_curve::{CurveArithmetic, PublicKey};
 use kem::{Decapsulate, Encapsulate};
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 
 pub struct ArithmeticKem<C: CurveArithmetic>(PhantomData<C>);
 
-impl<C> Encapsulate<PublicKey<C>, SharedSecret<C>> for Encapsulator<PublicKey<C>>
+impl<C> Encapsulate<PublicKey<C>, SharedSecret<C>> for DhEncapsulator<PublicKey<C>>
 where
     C: CurveArithmetic,
 {
@@ -26,7 +26,7 @@ where
     }
 }
 
-impl<C> Decapsulate<PublicKey<C>, SharedSecret<C>> for Decapsulator<EphemeralSecret<C>>
+impl<C> Decapsulate<PublicKey<C>, SharedSecret<C>> for DhDecapsulator<EphemeralSecret<C>>
 where
     C: CurveArithmetic,
 {
@@ -43,8 +43,8 @@ impl<C> DhKem for ArithmeticKem<C>
 where
     C: CurveArithmetic,
 {
-    type DecapsulatingKey = Decapsulator<EphemeralSecret<C>>;
-    type EncapsulatingKey = Encapsulator<PublicKey<C>>;
+    type DecapsulatingKey = DhDecapsulator<EphemeralSecret<C>>;
+    type EncapsulatingKey = DhEncapsulator<PublicKey<C>>;
     type EncapsulatedKey = PublicKey<C>;
     type SharedSecret = SharedSecret<C>;
 
@@ -54,6 +54,6 @@ where
         let sk = EphemeralSecret::random(rng);
         let pk = PublicKey::from(&sk);
 
-        (Decapsulator(sk), Encapsulator(pk))
+        (DhDecapsulator(sk), DhEncapsulator(pk))
     }
 }

--- a/dhkem/src/arithmetic.rs
+++ b/dhkem/src/arithmetic.rs
@@ -33,7 +33,7 @@ where
     type Error = ();
 
     fn decapsulate(&self, encapsulated_key: &PublicKey<C>) -> Result<SharedSecret<C>, Self::Error> {
-        let ss = self.0.diffie_hellman(&encapsulated_key);
+        let ss = self.0.diffie_hellman(encapsulated_key);
 
         Ok(ss)
     }

--- a/dhkem/src/hpke_p256_test.rs
+++ b/dhkem/src/hpke_p256_test.rs
@@ -1,0 +1,107 @@
+use crate::{DhKem, NistP256};
+use elliptic_curve::sec1::ToEncodedPoint;
+use hex_literal::hex;
+use hkdf::Hkdf;
+use kem::{Decapsulate, Encapsulate};
+use rand_core::{CryptoRng, RngCore};
+use sha2::Sha256;
+
+/// Constant RNG for testing purposes only.
+struct ConstantRng<'a>(pub &'a [u8]);
+
+impl<'a> RngCore for ConstantRng<'a> {
+    fn next_u32(&mut self) -> u32 {
+        let (head, tail) = self.0.split_at(4);
+        self.0 = tail;
+        u32::from_be_bytes(head.try_into().unwrap())
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let (head, tail) = self.0.split_at(8);
+        self.0 = tail;
+        u64::from_be_bytes(head.try_into().unwrap())
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        let (hd, tl) = self.0.split_at(dest.len());
+        dest.copy_from_slice(hd);
+        self.0 = tl;
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        if dest.len() > self.0.len() {
+            return Err(rand_core::Error::new("not enough bytes"));
+        }
+        let (hd, tl) = self.0.split_at(dest.len());
+        dest.copy_from_slice(hd);
+        self.0 = tl;
+        Ok(())
+    }
+}
+
+// this is only ever ok for testing
+impl CryptoRng for ConstantRng<'_> {}
+
+fn labeled_extract(salt: &[u8], label: &[u8], ikm: &[u8]) -> Vec<u8> {
+    let labeled_ikm = [b"HPKE-v1".as_slice(), b"KEM\x00\x10".as_slice(), label, ikm].concat();
+    Hkdf::<Sha256>::extract(Some(salt), &labeled_ikm).0.to_vec()
+}
+
+fn labeled_expand(prk: &[u8], label: &[u8], info: &[u8], l: u16) -> Vec<u8> {
+    let labeled_info = [
+        &l.to_be_bytes(),
+        b"HPKE-v1".as_slice(),
+        b"KEM\x00\x10".as_slice(),
+        label,
+        info,
+    ]
+    .concat();
+    let mut out = Vec::with_capacity(l as usize);
+    out.resize(l as usize, 0);
+    Hkdf::<Sha256>::from_prk(prk)
+        .unwrap()
+        .expand(&labeled_info, &mut out)
+        .expect("ok");
+    out
+}
+
+fn extract_and_expand(dh: <NistP256 as DhKem>::SharedSecret, kem_context: &[u8]) -> Vec<u8> {
+    let eae_prk = labeled_extract(b"", b"eae_prk", dh.raw_secret_bytes());
+    labeled_expand(&eae_prk, b"shared_secret", kem_context, 32)
+}
+
+#[test]
+// section A.3.1 https://datatracker.ietf.org/doc/html/rfc9180#appendix-A.3.1
+fn test_dhkem_p256_hkdf_sha256() {
+    let pke_hex = hex!(
+        "04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b32\
+                  5ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4"
+    );
+    let pkr_hex = hex!(
+        "04fe8c19ce0905191ebc298a9245792531f26f0cece2460639e8bc39cb7f70\
+                  6a826a779b4cf969b8a0e539c7f62fb3d30ad6aa8f80e30f1d128aafd68a2ce72ea0"
+    );
+    let shared_secret_hex =
+        hex!("c0d26aeab536609a572b07695d933b589dcf363ff9d93c93adea537aeabb8cb8");
+
+    let (skr, pkr) = NistP256::random_keypair(&mut ConstantRng(&hex!(
+        "f3ce7fdae57e1a310d87f1ebbde6f328be0a99cdbcadf4d6589cf29de4b8ffd2"
+    )));
+    assert_eq!(pkr.0.to_encoded_point(false).as_bytes(), &pkr_hex);
+
+    let (pke, ss1) = pkr
+        .encapsulate(&mut ConstantRng(&hex!(
+            "4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb"
+        )))
+        .expect("never fails");
+    assert_eq!(pke.to_encoded_point(false).as_bytes(), &pke_hex);
+
+    let ss2 = skr.decapsulate(&pke).expect("never fails");
+
+    assert_eq!(ss1.raw_secret_bytes(), ss2.raw_secret_bytes());
+
+    let kem_context = [pke_hex, pkr_hex].concat();
+    let shared_secret = extract_and_expand(ss1, &kem_context);
+
+    assert_eq!(&shared_secret, &shared_secret_hex);
+}

--- a/dhkem/src/lib.rs
+++ b/dhkem/src/lib.rs
@@ -1,7 +1,14 @@
 use kem::{Decapsulate, Encapsulate};
 use rand_core::CryptoRngCore;
 
-pub struct DhKemProxy<X>(X);
+/// Newtype for a piece of data that may be encapsulated
+pub struct Encapsulator<X>(X);
+/// Newtype for a piece of data that may be decapsulated
+pub struct Decapsulator<X>(X);
+/// Newtype for a shared secret
+pub struct SharedSecret<X>(X);
+/// Newtype for an encapsulated key
+pub struct EncapsulatedKey<X>(X);
 
 #[cfg(test)]
 pub trait SecretBytes {

--- a/dhkem/src/lib.rs
+++ b/dhkem/src/lib.rs
@@ -5,10 +5,6 @@ use rand_core::CryptoRngCore;
 pub struct Encapsulator<X>(X);
 /// Newtype for a piece of data that may be decapsulated
 pub struct Decapsulator<X>(X);
-/// Newtype for a shared secret
-pub struct SharedSecret<X>(X);
-/// Newtype for an encapsulated key
-pub struct EncapsulatedKey<X>(X);
 
 #[cfg(test)]
 pub trait SecretBytes {

--- a/dhkem/src/lib.rs
+++ b/dhkem/src/lib.rs
@@ -135,3 +135,7 @@ pub type Sm2 = arithmetic::ArithmeticKem<sm2::Sm2>;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+#[cfg(feature = "p256")]
+mod hpke_p256_test;

--- a/dhkem/src/lib.rs
+++ b/dhkem/src/lib.rs
@@ -3,11 +3,20 @@ use rand_core::CryptoRngCore;
 
 pub struct DhKemProxy<X>(X);
 
+#[cfg(test)]
+pub trait SecretBytes {
+    fn as_slice(&self) -> &[u8];
+}
+
 pub trait DhKem {
     type DecapsulatingKey: Decapsulate<Self::EncapsulatedKey, Self::SharedSecret>;
     type EncapsulatingKey: Encapsulate<Self::EncapsulatedKey, Self::SharedSecret>;
     type EncapsulatedKey;
+    #[cfg(not(test))]
     type SharedSecret;
+
+    #[cfg(test)]
+    type SharedSecret: SecretBytes;
 
     fn random_keypair(
         rng: &mut impl CryptoRngCore,
@@ -41,3 +50,6 @@ pub type NistP384 = arithmetic::ArithmeticKem<p384::NistP384>;
 pub type NistP521 = arithmetic::ArithmeticKem<p521::NistP521>;
 #[cfg(feature = "sm2")]
 pub type Sm2 = arithmetic::ArithmeticKem<sm2::Sm2>;
+
+#[cfg(test)]
+mod tests;

--- a/dhkem/src/lib.rs
+++ b/dhkem/src/lib.rs
@@ -57,11 +57,6 @@ impl<X> Decapsulator<X> {
     }
 }
 
-#[cfg(test)]
-pub trait SecretBytes {
-    fn as_slice(&self) -> &[u8];
-}
-
 /// This is a trait that all KEM models should implement, and should probably be
 /// promoted to the kem crate itself. It specifies the types of encapsulating and
 /// decapsulating keys created by key generation, the shared secret type, and the
@@ -76,12 +71,8 @@ pub trait DhKem {
     /// The type of the encapsulated key
     type EncapsulatedKey;
 
-    #[cfg(not(test))]
     /// The type of the shared secret
     type SharedSecret;
-
-    #[cfg(test)]
-    type SharedSecret: SecretBytes;
 
     /// Generates a new (decapsulating key, encapsulating key) keypair for the KEM
     /// model

--- a/dhkem/src/lib.rs
+++ b/dhkem/src/lib.rs
@@ -13,9 +13,49 @@ use kem::{Decapsulate, Encapsulate};
 use rand_core::CryptoRngCore;
 
 /// Newtype for a piece of data that may be encapsulated
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Default)]
 pub struct Encapsulator<X>(X);
 /// Newtype for a piece of data that may be decapsulated
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Default)]
 pub struct Decapsulator<X>(X);
+
+impl<X> AsRef<X> for Encapsulator<X> {
+    fn as_ref(&self) -> &X {
+        &self.0
+    }
+}
+
+impl<X> From<X> for Encapsulator<X> {
+    fn from(value: X) -> Self {
+        Self(value)
+    }
+}
+
+impl<X> AsRef<X> for Decapsulator<X> {
+    fn as_ref(&self) -> &X {
+        &self.0
+    }
+}
+
+impl<X> From<X> for Decapsulator<X> {
+    fn from(value: X) -> Self {
+        Self(value)
+    }
+}
+
+impl<X> Encapsulator<X> {
+    /// Consumes `self` and returns the wrapped value
+    pub fn into_inner(self) -> X {
+        self.0
+    }
+}
+
+impl<X> Decapsulator<X> {
+    /// Consumes `self` and returns the wrapped value
+    pub fn into_inner(self) -> X {
+        self.0
+    }
+}
 
 #[cfg(test)]
 pub trait SecretBytes {

--- a/dhkem/src/lib.rs
+++ b/dhkem/src/lib.rs
@@ -1,0 +1,43 @@
+use kem::{Decapsulate, Encapsulate};
+use rand_core::CryptoRngCore;
+
+pub struct DhKemProxy<X>(X);
+
+pub trait DhKem {
+    type DecapsulatingKey: Decapsulate<Self::EncapsulatedKey, Self::SharedSecret>;
+    type EncapsulatingKey: Encapsulate<Self::EncapsulatedKey, Self::SharedSecret>;
+    type EncapsulatedKey;
+    type SharedSecret;
+
+    fn random_keypair(
+        rng: &mut impl CryptoRngCore,
+    ) -> (Self::DecapsulatingKey, Self::EncapsulatingKey);
+}
+
+#[cfg(feature = "arithmetic")]
+mod arithmetic;
+
+#[cfg(feature = "x25519")]
+mod x25519_kem;
+#[cfg(feature = "x25519")]
+pub use x25519_kem::X25519;
+
+#[cfg(feature = "bign256")]
+pub type BignP256 = arithmetic::ArithmeticKem<bign256::BignP256>;
+#[cfg(feature = "k256")]
+pub type Secp256k1 = arithmetic::ArithmeticKem<k256::Secp256k1>;
+#[cfg(feature = "p192")]
+pub type NistP192 = arithmetic::ArithmeticKem<p192::NistP192>;
+#[cfg(feature = "p224")]
+pub type NistP224 = arithmetic::ArithmeticKem<p224::NistP224>;
+#[cfg(feature = "p256")]
+pub type NistP256 = arithmetic::ArithmeticKem<p256::NistP256>;
+// include an additional alias Secp256r1 = NistP256
+#[cfg(feature = "p256")]
+pub type Secp256r1 = arithmetic::ArithmeticKem<p256::NistP256>;
+#[cfg(feature = "p384")]
+pub type NistP384 = arithmetic::ArithmeticKem<p384::NistP384>;
+#[cfg(feature = "p521")]
+pub type NistP521 = arithmetic::ArithmeticKem<p521::NistP521>;
+#[cfg(feature = "sm2")]
+pub type Sm2 = arithmetic::ArithmeticKem<sm2::Sm2>;

--- a/dhkem/src/lib.rs
+++ b/dhkem/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! # Diffie-Hellman (DH) based Key Encapsulation Mechanisms (KEM)
 //!
 //! This crate provides a KEM interface for DH protocols as specified in
@@ -11,51 +13,73 @@
 
 use kem::{Decapsulate, Encapsulate};
 use rand_core::CryptoRngCore;
+#[cfg(feature = "zeroize")]
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Newtype for a piece of data that may be encapsulated
 #[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Default)]
-pub struct Encapsulator<X>(X);
+pub struct DhEncapsulator<X>(X);
 /// Newtype for a piece of data that may be decapsulated
 #[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Default)]
-pub struct Decapsulator<X>(X);
+pub struct DhDecapsulator<X>(X);
 
-impl<X> AsRef<X> for Encapsulator<X> {
+impl<X> AsRef<X> for DhEncapsulator<X> {
     fn as_ref(&self) -> &X {
         &self.0
     }
 }
 
-impl<X> From<X> for Encapsulator<X> {
+impl<X> From<X> for DhEncapsulator<X> {
     fn from(value: X) -> Self {
         Self(value)
     }
 }
 
-impl<X> AsRef<X> for Decapsulator<X> {
+impl<X> AsRef<X> for DhDecapsulator<X> {
     fn as_ref(&self) -> &X {
         &self.0
     }
 }
 
-impl<X> From<X> for Decapsulator<X> {
+impl<X> From<X> for DhDecapsulator<X> {
     fn from(value: X) -> Self {
         Self(value)
     }
 }
 
-impl<X> Encapsulator<X> {
+impl<X> DhEncapsulator<X> {
     /// Consumes `self` and returns the wrapped value
     pub fn into_inner(self) -> X {
         self.0
     }
 }
 
-impl<X> Decapsulator<X> {
+impl<X> DhDecapsulator<X> {
     /// Consumes `self` and returns the wrapped value
     pub fn into_inner(self) -> X {
         self.0
     }
 }
+
+#[cfg(feature = "zeroize")]
+impl<X: Zeroize> Zeroize for DhEncapsulator<X> {
+    fn zeroize(&mut self) {
+        self.0.zeroize()
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<X: Zeroize> Zeroize for DhDecapsulator<X> {
+    fn zeroize(&mut self) {
+        self.0.zeroize()
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<X: ZeroizeOnDrop> ZeroizeOnDrop for DhEncapsulator<X> {}
+
+#[cfg(feature = "zeroize")]
+impl<X: ZeroizeOnDrop> ZeroizeOnDrop for DhDecapsulator<X> {}
 
 /// This is a trait that all KEM models should implement, and should probably be
 /// promoted to the kem crate itself. It specifies the types of encapsulating and

--- a/dhkem/src/tests.rs
+++ b/dhkem/src/tests.rs
@@ -1,0 +1,66 @@
+use crate::{DhKem, SecretBytes};
+use kem::{Decapsulate, Encapsulate};
+use rand::thread_rng;
+
+fn test_kem<K: DhKem>() {
+    let mut rng = thread_rng();
+    let (sk, pk) = K::random_keypair(&mut rng);
+    let (ek, ss1) = pk.encapsulate(&mut rng).expect("never fails");
+    let ss2 = sk.decapsulate(&ek).expect("never fails");
+
+    assert_eq!(ss1.as_slice(), ss2.as_slice());
+}
+
+#[cfg(feature = "x25519")]
+#[test]
+fn test_x25519() {
+    test_kem::<crate::X25519>();
+}
+
+#[cfg(feature = "bign256")]
+#[test]
+fn test_bign256() {
+    test_kem::<crate::BignP256>();
+}
+
+#[cfg(feature = "k256")]
+#[test]
+fn test_k256() {
+    test_kem::<crate::Secp256k1>();
+}
+
+#[cfg(feature = "p192")]
+#[test]
+fn test_p192() {
+    test_kem::<crate::NistP192>();
+}
+
+#[cfg(feature = "p224")]
+#[test]
+fn test_p224() {
+    test_kem::<crate::NistP224>();
+}
+
+#[cfg(feature = "p256")]
+#[test]
+fn test_p256() {
+    test_kem::<crate::NistP256>();
+}
+
+#[cfg(feature = "p384")]
+#[test]
+fn test_p384() {
+    test_kem::<crate::NistP384>();
+}
+
+#[cfg(feature = "p521")]
+#[test]
+fn test_p521() {
+    test_kem::<crate::NistP521>();
+}
+
+#[cfg(feature = "sm2")]
+#[test]
+fn test_sm2() {
+    test_kem::<crate::Sm2>();
+}

--- a/dhkem/src/tests.rs
+++ b/dhkem/src/tests.rs
@@ -2,6 +2,9 @@ use crate::{DhKem, SecretBytes};
 use kem::{Decapsulate, Encapsulate};
 use rand::thread_rng;
 
+// we need this because if the crate is compiled with no features this function never
+// gets used
+#[allow(dead_code)]
 fn test_kem<K: DhKem>() {
     let mut rng = thread_rng();
     let (sk, pk) = K::random_keypair(&mut rng);

--- a/dhkem/src/x25519_kem.rs
+++ b/dhkem/src/x25519_kem.rs
@@ -49,3 +49,10 @@ impl DhKem for X25519 {
         (DhKemProxy(sk), DhKemProxy(pk))
     }
 }
+
+#[cfg(test)]
+impl crate::SecretBytes for DhKemProxy<SharedSecret> {
+    fn as_slice(&self) -> &[u8] {
+        self.0.as_bytes().as_slice()
+    }
+}

--- a/dhkem/src/x25519_kem.rs
+++ b/dhkem/src/x25519_kem.rs
@@ -1,0 +1,51 @@
+use crate::{DhKem, DhKemProxy};
+use kem::{Decapsulate, Encapsulate};
+use rand_core::CryptoRngCore;
+use x25519::{PublicKey, ReusableSecret, SharedSecret};
+
+pub struct X25519;
+
+impl Encapsulate<DhKemProxy<PublicKey>, DhKemProxy<SharedSecret>> for DhKemProxy<PublicKey> {
+    type Error = ();
+
+    fn encapsulate(
+        &self,
+        rng: &mut impl CryptoRngCore,
+    ) -> Result<(DhKemProxy<PublicKey>, DhKemProxy<SharedSecret>), Self::Error> {
+        // ECDH encapsulation involves creating a new ephemeral key pair and then doing DH
+        let sk = ReusableSecret::random_from_rng(rng);
+        let pk = PublicKey::from(&sk);
+        let ss = sk.diffie_hellman(&self.0);
+
+        Ok((DhKemProxy(pk), DhKemProxy(ss)))
+    }
+}
+
+impl Decapsulate<DhKemProxy<PublicKey>, DhKemProxy<SharedSecret>> for DhKemProxy<ReusableSecret> {
+    type Error = ();
+
+    fn decapsulate(
+        &self,
+        encapsulated_key: &DhKemProxy<PublicKey>,
+    ) -> Result<DhKemProxy<SharedSecret>, Self::Error> {
+        let ss = self.0.diffie_hellman(&encapsulated_key.0);
+
+        Ok(DhKemProxy(ss))
+    }
+}
+
+impl DhKem for X25519 {
+    type DecapsulatingKey = DhKemProxy<ReusableSecret>;
+    type EncapsulatingKey = DhKemProxy<PublicKey>;
+    type EncapsulatedKey = DhKemProxy<PublicKey>;
+    type SharedSecret = DhKemProxy<SharedSecret>;
+
+    fn random_keypair(
+        rng: &mut impl CryptoRngCore,
+    ) -> (Self::DecapsulatingKey, Self::EncapsulatingKey) {
+        let sk = ReusableSecret::random_from_rng(rng);
+        let pk = PublicKey::from(&sk);
+
+        (DhKemProxy(sk), DhKemProxy(pk))
+    }
+}

--- a/dhkem/src/x25519_kem.rs
+++ b/dhkem/src/x25519_kem.rs
@@ -1,44 +1,48 @@
-use crate::{DhKem, DhKemProxy};
+use crate::{Decapsulator, DhKem, EncapsulatedKey, Encapsulator, SharedSecret};
 use kem::{Decapsulate, Encapsulate};
 use rand_core::CryptoRngCore;
-use x25519::{PublicKey, ReusableSecret, SharedSecret};
+use x25519::{PublicKey, ReusableSecret, SharedSecret as X25519Secret};
 
 pub struct X25519;
 
-impl Encapsulate<DhKemProxy<PublicKey>, DhKemProxy<SharedSecret>> for DhKemProxy<PublicKey> {
+impl Encapsulate<EncapsulatedKey<PublicKey>, SharedSecret<X25519Secret>>
+    for Encapsulator<PublicKey>
+{
     type Error = ();
 
     fn encapsulate(
         &self,
         rng: &mut impl CryptoRngCore,
-    ) -> Result<(DhKemProxy<PublicKey>, DhKemProxy<SharedSecret>), Self::Error> {
+    ) -> Result<(EncapsulatedKey<PublicKey>, SharedSecret<X25519Secret>), Self::Error> {
         // ECDH encapsulation involves creating a new ephemeral key pair and then doing DH
         let sk = ReusableSecret::random_from_rng(rng);
         let pk = PublicKey::from(&sk);
         let ss = sk.diffie_hellman(&self.0);
 
-        Ok((DhKemProxy(pk), DhKemProxy(ss)))
+        Ok((EncapsulatedKey(pk), SharedSecret(ss)))
     }
 }
 
-impl Decapsulate<DhKemProxy<PublicKey>, DhKemProxy<SharedSecret>> for DhKemProxy<ReusableSecret> {
+impl Decapsulate<EncapsulatedKey<PublicKey>, SharedSecret<X25519Secret>>
+    for Decapsulator<ReusableSecret>
+{
     type Error = ();
 
     fn decapsulate(
         &self,
-        encapsulated_key: &DhKemProxy<PublicKey>,
-    ) -> Result<DhKemProxy<SharedSecret>, Self::Error> {
+        encapsulated_key: &EncapsulatedKey<PublicKey>,
+    ) -> Result<SharedSecret<X25519Secret>, Self::Error> {
         let ss = self.0.diffie_hellman(&encapsulated_key.0);
 
-        Ok(DhKemProxy(ss))
+        Ok(SharedSecret(ss))
     }
 }
 
 impl DhKem for X25519 {
-    type DecapsulatingKey = DhKemProxy<ReusableSecret>;
-    type EncapsulatingKey = DhKemProxy<PublicKey>;
-    type EncapsulatedKey = DhKemProxy<PublicKey>;
-    type SharedSecret = DhKemProxy<SharedSecret>;
+    type DecapsulatingKey = Decapsulator<ReusableSecret>;
+    type EncapsulatingKey = Encapsulator<PublicKey>;
+    type EncapsulatedKey = EncapsulatedKey<PublicKey>;
+    type SharedSecret = SharedSecret<X25519Secret>;
 
     fn random_keypair(
         rng: &mut impl CryptoRngCore,
@@ -46,12 +50,12 @@ impl DhKem for X25519 {
         let sk = ReusableSecret::random_from_rng(rng);
         let pk = PublicKey::from(&sk);
 
-        (DhKemProxy(sk), DhKemProxy(pk))
+        (Decapsulator(sk), Encapsulator(pk))
     }
 }
 
 #[cfg(test)]
-impl crate::SecretBytes for DhKemProxy<SharedSecret> {
+impl crate::SecretBytes for SharedSecret<X25519Secret> {
     fn as_slice(&self) -> &[u8] {
         self.0.as_bytes().as_slice()
     }

--- a/dhkem/src/x25519_kem.rs
+++ b/dhkem/src/x25519_kem.rs
@@ -1,11 +1,11 @@
-use crate::{Decapsulator, DhKem, Encapsulator};
+use crate::{DhDecapsulator, DhKem, DhEncapsulator};
 use kem::{Decapsulate, Encapsulate};
 use rand_core::CryptoRngCore;
 use x25519::{PublicKey, ReusableSecret, SharedSecret};
 
 pub struct X25519;
 
-impl Encapsulate<PublicKey, SharedSecret> for Encapsulator<PublicKey> {
+impl Encapsulate<PublicKey, SharedSecret> for DhEncapsulator<PublicKey> {
     type Error = ();
 
     fn encapsulate(
@@ -21,7 +21,7 @@ impl Encapsulate<PublicKey, SharedSecret> for Encapsulator<PublicKey> {
     }
 }
 
-impl Decapsulate<PublicKey, SharedSecret> for Decapsulator<ReusableSecret> {
+impl Decapsulate<PublicKey, SharedSecret> for DhDecapsulator<ReusableSecret> {
     type Error = ();
 
     fn decapsulate(&self, encapsulated_key: &PublicKey) -> Result<SharedSecret, Self::Error> {
@@ -32,8 +32,8 @@ impl Decapsulate<PublicKey, SharedSecret> for Decapsulator<ReusableSecret> {
 }
 
 impl DhKem for X25519 {
-    type DecapsulatingKey = Decapsulator<ReusableSecret>;
-    type EncapsulatingKey = Encapsulator<PublicKey>;
+    type DecapsulatingKey = DhDecapsulator<ReusableSecret>;
+    type EncapsulatingKey = DhEncapsulator<PublicKey>;
     type EncapsulatedKey = PublicKey;
     type SharedSecret = SharedSecret;
 
@@ -43,6 +43,6 @@ impl DhKem for X25519 {
         let sk = ReusableSecret::random_from_rng(rng);
         let pk = PublicKey::from(&sk);
 
-        (Decapsulator(sk), Encapsulator(pk))
+        (DhDecapsulator(sk), DhEncapsulator(pk))
     }
 }

--- a/dhkem/src/x25519_kem.rs
+++ b/dhkem/src/x25519_kem.rs
@@ -1,48 +1,41 @@
-use crate::{Decapsulator, DhKem, EncapsulatedKey, Encapsulator, SharedSecret};
+use crate::{Decapsulator, DhKem, Encapsulator};
 use kem::{Decapsulate, Encapsulate};
 use rand_core::CryptoRngCore;
-use x25519::{PublicKey, ReusableSecret, SharedSecret as X25519Secret};
+use x25519::{PublicKey, ReusableSecret, SharedSecret};
 
 pub struct X25519;
 
-impl Encapsulate<EncapsulatedKey<PublicKey>, SharedSecret<X25519Secret>>
-    for Encapsulator<PublicKey>
-{
+impl Encapsulate<PublicKey, SharedSecret> for Encapsulator<PublicKey> {
     type Error = ();
 
     fn encapsulate(
         &self,
         rng: &mut impl CryptoRngCore,
-    ) -> Result<(EncapsulatedKey<PublicKey>, SharedSecret<X25519Secret>), Self::Error> {
+    ) -> Result<(PublicKey, SharedSecret), Self::Error> {
         // ECDH encapsulation involves creating a new ephemeral key pair and then doing DH
         let sk = ReusableSecret::random_from_rng(rng);
         let pk = PublicKey::from(&sk);
         let ss = sk.diffie_hellman(&self.0);
 
-        Ok((EncapsulatedKey(pk), SharedSecret(ss)))
+        Ok((pk, ss))
     }
 }
 
-impl Decapsulate<EncapsulatedKey<PublicKey>, SharedSecret<X25519Secret>>
-    for Decapsulator<ReusableSecret>
-{
+impl Decapsulate<PublicKey, SharedSecret> for Decapsulator<ReusableSecret> {
     type Error = ();
 
-    fn decapsulate(
-        &self,
-        encapsulated_key: &EncapsulatedKey<PublicKey>,
-    ) -> Result<SharedSecret<X25519Secret>, Self::Error> {
-        let ss = self.0.diffie_hellman(&encapsulated_key.0);
+    fn decapsulate(&self, encapsulated_key: &PublicKey) -> Result<SharedSecret, Self::Error> {
+        let ss = self.0.diffie_hellman(&encapsulated_key);
 
-        Ok(SharedSecret(ss))
+        Ok(ss)
     }
 }
 
 impl DhKem for X25519 {
     type DecapsulatingKey = Decapsulator<ReusableSecret>;
     type EncapsulatingKey = Encapsulator<PublicKey>;
-    type EncapsulatedKey = EncapsulatedKey<PublicKey>;
-    type SharedSecret = SharedSecret<X25519Secret>;
+    type EncapsulatedKey = PublicKey;
+    type SharedSecret = SharedSecret;
 
     fn random_keypair(
         rng: &mut impl CryptoRngCore,
@@ -55,8 +48,8 @@ impl DhKem for X25519 {
 }
 
 #[cfg(test)]
-impl crate::SecretBytes for SharedSecret<X25519Secret> {
+impl crate::SecretBytes for SharedSecret {
     fn as_slice(&self) -> &[u8] {
-        self.0.as_bytes().as_slice()
+        self.as_bytes().as_slice()
     }
 }

--- a/dhkem/src/x25519_kem.rs
+++ b/dhkem/src/x25519_kem.rs
@@ -25,7 +25,7 @@ impl Decapsulate<PublicKey, SharedSecret> for DhDecapsulator<ReusableSecret> {
     type Error = ();
 
     fn decapsulate(&self, encapsulated_key: &PublicKey) -> Result<SharedSecret, Self::Error> {
-        let ss = self.0.diffie_hellman(&encapsulated_key);
+        let ss = self.0.diffie_hellman(encapsulated_key);
 
         Ok(ss)
     }

--- a/dhkem/src/x25519_kem.rs
+++ b/dhkem/src/x25519_kem.rs
@@ -1,4 +1,4 @@
-use crate::{DhDecapsulator, DhKem, DhEncapsulator};
+use crate::{DhDecapsulator, DhEncapsulator, DhKem};
 use kem::{Decapsulate, Encapsulate};
 use rand_core::CryptoRngCore;
 use x25519::{PublicKey, ReusableSecret, SharedSecret};

--- a/dhkem/src/x25519_kem.rs
+++ b/dhkem/src/x25519_kem.rs
@@ -46,10 +46,3 @@ impl DhKem for X25519 {
         (Decapsulator(sk), Encapsulator(pk))
     }
 }
-
-#[cfg(test)]
-impl crate::SecretBytes for SharedSecret {
-    fn as_slice(&self) -> &[u8] {
-        self.as_bytes().as_slice()
-    }
-}


### PR DESCRIPTION
This replaces RustCrypto/traits#1556 and puts the `Encapsulate` and `Decapsulate` implementations into their own newtype. It probably needs some actual documentation at some point as well.

As an extension, maybe the `DhKem` trait should be promoted `traits/kem` as `KEM`, as `KeyGen() -> (PrivateKey, PublicKey)` is also part of the standard KEM model and provides a central trait for `impl<k1, k2> KEM for TlsKemCombiner<k1, k2> where k1, k2: KEM`. That way, we can just write `type X25519Kyber768Draft00 = TlsKemCombiner<dhkem::X25519, MlKem768>` once the `ml-kem` crate gets updated.