### PR TITLE
ml-kem: fix potential kyberslash attack

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.78.0
+      - uses: dtolnay/rust-toolchain@beta # TODO: use `1.79` after 2024-06-13
         with:
           components: clippy
       - run: cargo clippy -- -D warnings

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.74.0
+      - uses: dtolnay/rust-toolchain@1.78.0
         with:
           components: clippy
       - run: cargo clippy -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,9 +349,40 @@ dependencies = [
  "hex-literal",
  "hybrid-array",
  "kem",
+ "num-rational",
  "rand",
  "rand_core",
  "sha3",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -28,6 +28,7 @@ sha3 = { version = "0.10.8", default-features = false }
 criterion = "0.5.1"
 hex = "0.4.3"
 hex-literal = "0.4.1"
+num-rational = { version = "0.4.2", default-features = false, features = ["num-bigint"] }
 rand = "0.8.5"
 
 [[bench]]

--- a/ml-kem/src/algebra.rs
+++ b/ml-kem/src/algebra.rs
@@ -19,6 +19,7 @@ impl FieldElement {
     pub const Q32: u32 = Self::Q as u32;
     pub const Q64: u64 = Self::Q as u64;
     const BARRETT_SHIFT: usize = 24;
+    #[allow(clippy::integer_division_remainder_used)]
     const BARRETT_MULTIPLIER: u64 = (1 << Self::BARRETT_SHIFT) / Self::Q64;
 
     // A fast modular reduction for small numbers `x < 2*q`
@@ -263,6 +264,7 @@ impl NttPolynomial {
 #[allow(clippy::cast_possible_truncation)]
 const ZETA_POW_BITREV: [FieldElement; 128] = {
     const ZETA: u64 = 17;
+    #[allow(clippy::integer_division_remainder_used)]
     const fn bitrev7(x: usize) -> usize {
         ((x >> 6) % 2)
             | (((x >> 5) % 2) << 1)
@@ -277,6 +279,7 @@ const ZETA_POW_BITREV: [FieldElement; 128] = {
     let mut pow = [FieldElement(0); 128];
     let mut i = 0;
     let mut curr = 1u64;
+    #[allow(clippy::integer_division_remainder_used)]
     while i < 128 {
         pow[i] = FieldElement(curr as u16);
         i += 1;
@@ -300,6 +303,7 @@ const GAMMA: [FieldElement; 128] = {
     let mut i = 0;
     while i < 128 {
         let zpr = ZETA_POW_BITREV[i].0 as u64;
+        #[allow(clippy::integer_division_remainder_used)]
         let g = (zpr * zpr * ZETA) % FieldElement::Q64;
         gamma[i] = FieldElement(g as u16);
         i += 1;

--- a/ml-kem/src/algebra.rs
+++ b/ml-kem/src/algebra.rs
@@ -17,7 +17,7 @@ pub struct FieldElement(pub Integer);
 impl FieldElement {
     pub const Q: Integer = 3329;
     pub const Q32: u32 = Self::Q as u32;
-    const Q64: u64 = Self::Q as u64;
+    pub const Q64: u64 = Self::Q as u64;
     const BARRETT_SHIFT: usize = 24;
     const BARRETT_MULTIPLIER: u64 = (1 << Self::BARRETT_SHIFT) / Self::Q64;
 

--- a/ml-kem/src/compress.rs
+++ b/ml-kem/src/compress.rs
@@ -5,8 +5,9 @@ use crate::util::Truncate;
 // A convenience trait to allow us to associate some constants with a typenum
 pub trait CompressionFactor: EncodingSize {
     const POW2_HALF: u32;
+    const POW2: Integer;
     const MASK: Integer;
-    const DIV_SHIFT: u32;
+    const DIV_SHIFT: u64;
     const DIV_MUL: u64;
 }
 
@@ -15,8 +16,9 @@ where
     T: EncodingSize,
 {
     const POW2_HALF: u32 = 1 << (T::USIZE - 1);
+    const POW2: Integer = 1 << T::USIZE;
     const MASK: Integer = ((1 as Integer) << T::USIZE) - 1;
-    const DIV_SHIFT: u32 = 28 + (T::U32 >> 3) * 4;
+    const DIV_SHIFT: u64 = 32 + (T::U64 >> 3) * 4;
     #[allow(clippy::integer_division_remainder_used)]
     const DIV_MUL: u64 = (1 << T::DIV_SHIFT) / FieldElement::Q64;
 }
@@ -35,14 +37,14 @@ impl Compress for FieldElement {
     //   round(a / b) = floor((a + b/2) / b)
     //   a / q ~= (a * x) >> s where x >> s ~= 1/q
     fn compress<D: CompressionFactor>(&mut self) -> &Self {
-        const Q_HALF: u64 = (FieldElement::Q64 - 1) >> 1;
+        const Q_HALF: u64 = (FieldElement::Q64 + 1) >> 1;
         let x = u64::from(self.0);
         let y = ((((x << D::USIZE) + Q_HALF) * D::DIV_MUL) >> D::DIV_SHIFT).truncate();
         self.0 = y.truncate() & D::MASK;
         self
     }
 
-    // Equation 4.6: Decomporess_d(x) = round((q / 2^d) x)
+    // Equation 4.6: Decompress_d(x) = round((q / 2^d) x)
     fn decompress<D: CompressionFactor>(&mut self) -> &Self {
         let x = u32::from(self.0);
         let y = ((x * FieldElement::Q32) + D::POW2_HALF) >> D::USIZE;
@@ -50,7 +52,6 @@ impl Compress for FieldElement {
         self
     }
 }
-
 impl Compress for Polynomial {
     fn compress<D: CompressionFactor>(&mut self) -> &Self {
         for x in &mut self.0 {
@@ -91,29 +92,90 @@ impl<K: ArraySize> Compress for PolynomialVector<K> {
 pub(crate) mod test {
     use super::*;
     use hybrid_array::typenum::{U1, U10, U11, U12, U4, U5, U6};
+    use num_rational::Ratio;
+
+    fn rational_compress<D: CompressionFactor>(input: u16) -> u16 {
+        let fraction = Ratio::from_integer(input as u32) * u32::from(D::POW2) / FieldElement::Q32;
+        (fraction.round().to_integer() as u16) & D::MASK
+    }
+
+    fn rational_decompress<D: CompressionFactor>(input: u16) -> u16 {
+        let fraction = Ratio::from_integer(input as u32) * FieldElement::Q32 / u32::from(D::POW2);
+        fraction.round().to_integer() as u16
+    }
 
     // Verify against inequality 4.7
     #[allow(clippy::integer_division_remainder_used)]
     fn compression_decompression_inequality<D: CompressionFactor>() {
-        let half_q: i32 = i32::from(FieldElement::Q) / 2;
-        let error_threshold =
-            ((f64::from(FieldElement::Q)) / f64::from(1 << (D::U32 + 1))).round() as i32;
+        const QI32: i32 = FieldElement::Q as i32;
+        let threshold = Ratio::from_integer(FieldElement::Q) / D::POW2;
+        let error_threshold = threshold.to_integer() as i32;
+
         for x in 0..FieldElement::Q {
             let mut y = FieldElement(x);
 
             y.compress::<D>();
             y.decompress::<D>();
 
-            let mut error = (i32::from(y.0) - i32::from(x)) % half_q;
-            if error < -half_q {
-                error += half_q;
+            let mut error = i32::from(y.0) - i32::from(x) + QI32;
+            if error > (QI32 - 1) / 2 {
+                error -= QI32;
             }
 
             assert!(
-                error <= error_threshold,
-                "Inequality failed for x = {x}: error = {error}, error_threshold = {error_threshold}, D = {:?}",
+                error.abs() <= error_threshold,
+                "Inequality failed for x = {x}: error = {}, error_threshold = {error_threshold}, D = {:?}",
+                error.abs(),
                 D::USIZE
             );
+        }
+    }
+
+    fn decompression_compression_equality<D: CompressionFactor>() {
+        for x in 0..(1 << D::USIZE) {
+            let mut y = FieldElement(x);
+            y.decompress::<D>();
+            y.compress::<D>();
+
+            let cd = rational_compress::<D>(rational_decompress::<D>(x));
+
+            assert_eq!(cd, y.0);
+
+            assert_eq!(y.0, x, "failed for x: {}, D: {}", x, D::USIZE);
+        }
+    }
+
+    fn decompress_KAT<D: CompressionFactor>() {
+        for y in 0..(1 << D::USIZE) {
+            let x_expected = rational_decompress::<D>(y);
+            let mut x_actual = FieldElement(y);
+            x_actual.decompress::<D>();
+
+            assert!(
+                x_actual.0 < FieldElement::Q,
+                "assertion x < Q failed for: x: {}, y: {}, D: {}",
+                x_actual.0,
+                y,
+                D::USIZE
+            );
+            assert_eq!(x_expected, x_actual.0);
+        }
+    }
+
+    fn compress_KAT<D: CompressionFactor>() {
+        for x in 0..FieldElement::Q {
+            let y_expected = rational_compress::<D>(x);
+            let mut y_actual = FieldElement(x);
+            y_actual.compress::<D>();
+
+            assert!(
+                y_actual.0 < (1 << D::USIZE),
+                "assertion y < Z_d failed for: y: {}, x: {}, D: {}",
+                y_actual.0,
+                x,
+                D::USIZE
+            );
+            assert_eq!(y_expected, y_actual.0, "for x: {}, D: {}", x, D::USIZE);
         }
     }
 
@@ -126,5 +188,38 @@ pub(crate) mod test {
         compression_decompression_inequality::<U10>();
         compression_decompression_inequality::<U11>();
         compression_decompression_inequality::<U12>();
+    }
+
+    #[test]
+    fn decompress_compress() {
+        decompression_compression_equality::<U1>();
+        decompression_compression_equality::<U4>();
+        decompression_compression_equality::<U5>();
+        decompression_compression_equality::<U6>();
+        decompression_compression_equality::<U10>();
+        decompression_compression_equality::<U11>();
+        // preservation of input only for d < 12
+    }
+
+    #[test]
+    fn decompress_test() {
+        decompress_KAT::<U1>();
+        decompress_KAT::<U4>();
+        decompress_KAT::<U5>();
+        decompress_KAT::<U6>();
+        decompress_KAT::<U10>();
+        decompress_KAT::<U11>();
+        decompress_KAT::<U12>();
+    }
+
+    #[test]
+    fn compress_test() {
+        compress_KAT::<U1>();
+        compress_KAT::<U4>();
+        compress_KAT::<U5>();
+        compress_KAT::<U6>();
+        compress_KAT::<U10>();
+        compress_KAT::<U11>();
+        compress_KAT::<U12>();
     }
 }

--- a/ml-kem/src/compress.rs
+++ b/ml-kem/src/compress.rs
@@ -17,6 +17,7 @@ where
     const POW2_HALF: u32 = 1 << (T::USIZE - 1);
     const MASK: Integer = ((1 as Integer) << T::USIZE) - 1;
     const DIV_SHIFT: u32 = 28 + (T::U32 >> 3) * 4;
+    #[allow(clippy::integer_division_remainder_used)]
     const DIV_MUL: u64 = (1 << T::DIV_SHIFT) / FieldElement::Q64;
 }
 
@@ -92,9 +93,10 @@ pub(crate) mod test {
     use hybrid_array::typenum::{U1, U10, U11, U12, U4, U5, U6};
 
     // Verify against inequality 4.7
+    #[allow(clippy::integer_division_remainder_used)]
     fn compression_decompression_inequality<D: CompressionFactor>() {
         let half_q: i32 = i32::from(FieldElement::Q) / 2;
-        let error_threshold = ((FieldElement::Q as f64) / ((1 << (D::U32 + 1)) as f64)).round() as i32;
+        let error_threshold = ((f64::from(FieldElement::Q)) / f64::from(1 << (D::U32 + 1))).round() as i32;
         for x in 0..FieldElement::Q {
             let mut y = FieldElement(x);
 

--- a/ml-kem/src/compress.rs
+++ b/ml-kem/src/compress.rs
@@ -96,7 +96,8 @@ pub(crate) mod test {
     #[allow(clippy::integer_division_remainder_used)]
     fn compression_decompression_inequality<D: CompressionFactor>() {
         let half_q: i32 = i32::from(FieldElement::Q) / 2;
-        let error_threshold = ((f64::from(FieldElement::Q)) / f64::from(1 << (D::U32 + 1))).round() as i32;
+        let error_threshold =
+            ((f64::from(FieldElement::Q)) / f64::from(1 << (D::U32 + 1))).round() as i32;
         for x in 0..FieldElement::Q {
             let mut y = FieldElement(x);
 
@@ -104,7 +105,7 @@ pub(crate) mod test {
             y.decompress::<D>();
 
             let mut error = (i32::from(y.0) - i32::from(x)) % half_q;
-            if error < - half_q {
+            if error < -half_q {
                 error += half_q;
             }
 

--- a/ml-kem/src/encode.rs
+++ b/ml-kem/src/encode.rs
@@ -165,11 +165,13 @@ pub(crate) mod test {
         D: ArraySize + Rem<N>,
         Mod<D, N>: Zero,
     {
+        #[allow(clippy::integer_division_remainder_used)]
         fn repeat(&self) -> Array<T, D> {
             Array::from_fn(|i| self[i % N::USIZE].clone())
         }
     }
 
+    #[allow(clippy::integer_division_remainder_used)]
     fn byte_codec_test<D>(decoded: DecodedValue, encoded: EncodedPolynomial<D>)
     where
         D: EncodingSize,
@@ -247,6 +249,7 @@ pub(crate) mod test {
         byte_codec_test::<U12>(decoded, encoded);
     }
 
+    #[allow(clippy::integer_division_remainder_used)]
     #[test]
     fn byte_codec_12_mod() {
         // DecodeBytes_12 is required to reduce mod q

--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -6,6 +6,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![warn(clippy::pedantic)] // Be pedantic by default
+#![warn(clippy::integer_division_remainder_used)]
 #![allow(non_snake_case)] // Allow notation matching the spec
 #![allow(clippy::clone_on_copy)] // Be explicit about moving data
 #![deny(missing_docs)] // Require all public interfaces to be documented

--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -6,7 +6,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![warn(clippy::pedantic)] // Be pedantic by default
-#![warn(clippy::integer_division_remainder_used)]
+#![warn(clippy::integer_division_remainder_used)] // Be judicious about using `/` and `%`
 #![allow(non_snake_case)] // Allow notation matching the spec
 #![allow(clippy::clone_on_copy)] // Be explicit about moving data
 #![deny(missing_docs)] // Require all public interfaces to be documented

--- a/ml-kem/src/param.rs
+++ b/ml-kem/src/param.rs
@@ -117,6 +117,7 @@ where
     let mut x = 0usize;
     while x < max {
         let mut y = 0usize;
+        #[allow(clippy::integer_division_remainder_used)]
         while y < max {
             let x_ones = x.count_ones() as u16;
             let y_ones = y.count_ones() as u16;


### PR DESCRIPTION
Updates the `compress` method to remove division of secret values by public value (q) as described in the [kyberslash attack](https://kyberslash.cr.yp.to/index.html)

Also updates tests to use inequality as per 4.7 in [FIPS 203 draft](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.ipd.pdf) to not use floating point arithmetic.

