### PR TITLE
ml-kem: fix benchmarking code

### DIFF
--- a/.github/workflows/ml-kem.yml
+++ b/.github/workflows/ml-kem.yml
@@ -64,6 +64,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - run: cargo build --benches --all-features
       - run: cargo test --no-default-features
       - run: cargo test
       - run: cargo test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -345,6 +346,7 @@ name = "ml-kem"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "crypto-common",
  "hex",
  "hex-literal",
  "hybrid-array",

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -29,6 +29,7 @@ criterion = "0.5.1"
 hex = "0.4.3"
 hex-literal = "0.4.1"
 rand = "0.8.5"
+crypto-common = { version = "0.1.6", features = ["rand_core"] }
 
 [[bench]]
 name = "mlkem"

--- a/ml-kem/benches/mlkem.rs
+++ b/ml-kem/benches/mlkem.rs
@@ -1,3 +1,4 @@
+use ::kem::{Decapsulate, Encapsulate};
 use criterion::{criterion_group, criterion_main, Criterion};
 use crypto_common::rand_core::CryptoRngCore;
 use hybrid_array::{Array, ArraySize};


### PR DESCRIPTION
Some late changes in #2 appear to have broken the benchmarking code.  This PR makes the few small changes needed to get it working again.