### PR TITLE
cargo: point `repository` metadata to clonable URLs

### DIFF
--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0 OR MIT"
 readme = "README.md"
-repository = "https://github.com/RustCrypto/KEMs/tree/master/ml-kem"
+homepage = "https://github.com/RustCrypto/KEMs/tree/master/ml-kem"
+repository = "https://github.com/RustCrypto/KEMs"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "kyber", "lattice", "post-quantum"]
 


### PR DESCRIPTION
This tweaks the `repository` fields in Cargo metadata in order to use the correct (i.e. git clonable) URL. The existing GitHub webUI URLs for each package have been retained and moved to `homepage` fields.