### PR TITLE
CI: run `clippy` on 1.79 stable

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@beta # TODO: use `1.79` after 2024-06-13
+      - uses: dtolnay/rust-toolchain@1.79
         with:
           components: clippy
       - run: cargo clippy -- -D warnings


### PR DESCRIPTION
Previously `beta` was used for the `integer_division_remainder_used` lint, which was stabilized in 1.79 which was released today.

Closes #27