### PR TITLE
Updates tests to use `try_from` instead of deprecated `from_slice`

### DIFF
--- a/ml-kem/src/crypto.rs
+++ b/ml-kem/src/crypto.rs
@@ -169,9 +169,10 @@ mod test {
 
     #[test]
     fn prf() {
-        let s = B32::from_slice("Input s to an invocation of PRF2".as_bytes());
+        let s = B32::try_from("Input s to an invocation of PRF2".as_bytes())
+            .expect("Failed to create B32 from slice");
         let b = b'b';
-        let actual = PRF::<U2>(s, b);
+        let actual = PRF::<U2>(&s, b);
         let expected = hex!(
             "54c002415c2219b564d5c17b0df0c82f83ddf3fdecc7d814ed5d85457c06c2c3\
              ed0b0584f926dffb1e57c6105f8604e81c4605b93f8284e44585104101042075\
@@ -180,9 +181,10 @@ mod test {
         );
         assert_eq!(actual, expected);
 
-        let s = B32::from_slice("Input s to an invocation of PRF3".as_bytes());
+        let s = B32::try_from("Input s to an invocation of PRF3".as_bytes())
+            .expect("Failed to create B32 from slice");
         let b = b'b';
-        let actual = PRF::<U3>(s, b);
+        let actual = PRF::<U3>(&s, b);
         let expected = hex!(
             "5e12028f67479b862a12713cda833e21b8ccd51bff9ddc2bfb9ab2910a9dc2e6\
              c58264a3f51ccc9ef4ff936a15505e016f60c36ffe300be01b9fb12eacd57867\
@@ -196,11 +198,12 @@ mod test {
 
     #[test]
     fn xof() {
-        let rho = B32::from_slice("Input rho, to an XOF invocation!".as_bytes());
+        let rho = B32::try_from("Input rho, to an XOF invocation!".as_bytes())
+            .expect("Failed to create B32 from slice");
         let i = b'i';
         let j = b'j';
 
-        let mut reader = XOF(rho, i, j);
+        let mut reader = XOF(&rho, i, j);
         let mut actual = [0u8; 32];
         reader.read(&mut actual);
 

--- a/ml-kem/tests/vectors.rs
+++ b/ml-kem/tests/vectors.rs
@@ -13,17 +13,17 @@ pub struct GenerateVector {
 
 impl GenerateVector {
     pub fn verify<K: KemCore>(&self) {
-        let d = Array::from_slice(&self.d);
-        let z = Array::from_slice(&self.z);
-        let (dk, ek) = K::generate_deterministic(d, z);
+        let d = Array::try_from(self.d).unwrap();
+        let z = Array::try_from(self.z).unwrap();
+        let (dk, ek) = K::generate_deterministic(&d, &z);
         assert_eq!(dk.as_bytes().as_slice(), self.dk);
         assert_eq!(ek.as_bytes().as_slice(), self.ek);
 
-        let dk_bytes = Encoded::<K::DecapsulationKey>::from_slice(self.dk);
-        assert_eq!(dk, K::DecapsulationKey::from_bytes(dk_bytes));
+        let dk_bytes = Encoded::<K::DecapsulationKey>::try_from(self.dk).unwrap();
+        assert_eq!(dk, K::DecapsulationKey::from_bytes(&dk_bytes));
 
-        let ek_bytes = Encoded::<K::EncapsulationKey>::from_slice(self.ek);
-        assert_eq!(ek, K::EncapsulationKey::from_bytes(ek_bytes));
+        let ek_bytes = Encoded::<K::EncapsulationKey>::try_from(self.ek).unwrap();
+        assert_eq!(ek, K::EncapsulationKey::from_bytes(&ek_bytes));
     }
 }
 
@@ -36,10 +36,10 @@ pub struct EncapsulateVector {
 
 impl EncapsulateVector {
     pub fn verify<K: KemCore>(&self) {
-        let m = Array::from_slice(&self.m);
-        let ek_bytes = Encoded::<K::EncapsulationKey>::from_slice(self.ek);
-        let ek = K::EncapsulationKey::from_bytes(ek_bytes);
-        let (c, k) = ek.encapsulate_deterministic(m).unwrap();
+        let m = Array::try_from(self.m).unwrap();
+        let ek_bytes = Encoded::<K::EncapsulationKey>::try_from(self.ek).unwrap();
+        let ek = K::EncapsulationKey::from_bytes(&ek_bytes);
+        let (c, k) = ek.encapsulate_deterministic(&m).unwrap();
         assert_eq!(k.as_slice(), &self.k);
         assert_eq!(c.as_slice(), self.c);
     }
@@ -53,11 +53,11 @@ pub struct DecapsulateVector {
 
 impl DecapsulateVector {
     pub fn verify<K: KemCore>(&self) {
-        let dk_bytes = Encoded::<K::DecapsulationKey>::from_slice(self.dk);
-        let dk = K::DecapsulationKey::from_bytes(dk_bytes);
+        let dk_bytes = Encoded::<K::DecapsulationKey>::try_from(self.dk).unwrap();
+        let dk = K::DecapsulationKey::from_bytes(&dk_bytes);
 
-        let c_bytes = Ciphertext::<K>::from_slice(self.c);
-        let k = dk.decapsulate(c_bytes).unwrap();
+        let c_bytes = Ciphertext::<K>::try_from(self.c).unwrap();
+        let k = dk.decapsulate(&c_bytes).unwrap();
         assert_eq!(k.as_slice(), &self.k);
     }
 }


### PR DESCRIPTION
Resolves failing workspace action due to newly deprecated method in `hybrid-array` giving clippy warnings in #33.

Uses expect as these are only tests and no need for fully fleshed out error handling.