### PR TITLE
dhkem: add `no_std` + refactor tests

### DIFF
--- a/.github/workflows/dhkem.yml
+++ b/.github/workflows/dhkem.yml
@@ -30,6 +30,26 @@ jobs:
     with:
       working-directory: ${{ github.workflow }}
 
+  no_std:
+    needs: set-msrv
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - ${{needs.set-msrv.outputs.msrv}}
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v4
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - run: cargo build --no-default-features --target ${{ matrix.target }}
+
   test:
     needs: set-msrv
     runs-on: ubuntu-latest

--- a/.github/workflows/ml-kem.yml
+++ b/.github/workflows/ml-kem.yml
@@ -23,6 +23,13 @@ jobs:
     with:
       msrv: 1.74.0
 
+  minimal-versions:
+    # temporarily disabled as requested by Tony (https://github.com/RustCrypto/KEMs/pull/15#pullrequestreview-2006378802)
+    if: false
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+      working-directory: ${{ github.workflow }}
+
   no_std:
     needs: set-msrv
     runs-on: ubuntu-latest
@@ -42,13 +49,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: cargo build --no-default-features --target ${{ matrix.target }}
-
-  minimal-versions:
-    # temporarily disabled as requested by Tony (https://github.com/RustCrypto/KEMs/pull/15#pullrequestreview-2006378802)
-    if: false
-    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-    with:
-      working-directory: ${{ github.workflow }}
 
   test:
     needs: set-msrv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,39 +36,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "belt-block"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
-
-[[package]]
-name = "belt-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc405b3b8472f6e019aedf942fdee9516a0546d12e053d3744416e8f21ddb8a"
-dependencies = [
- "belt-block",
- "digest",
-]
-
-[[package]]
 name = "bign256"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a060e09443574e5518c7eced1ef6ff33496be5aee6dc101f99102039d3922eff"
 dependencies = [
- "belt-hash",
- "crypto-bigint",
  "elliptic-curve",
  "primeorder",
- "rfc6979",
- "signature",
 ]
 
 [[package]]
@@ -268,7 +242,6 @@ dependencies = [
  "platforms",
  "rustc_version",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -289,7 +262,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -323,23 +295,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
 ]
 
 [[package]]
@@ -361,8 +318,6 @@ dependencies = [
  "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468",
- "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
@@ -515,11 +470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if",
- "ecdsa",
  "elliptic-curve",
- "once_cell",
- "sha2",
- "signature",
 ]
 
 [[package]]
@@ -632,7 +583,6 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b0533bc6c238f2669aab8db75ae52879dc74e88d6bd3685bd4022a00fa85cd2"
 dependencies = [
- "ecdsa",
  "elliptic-curve",
  "primeorder",
  "sec1",
@@ -644,10 +594,8 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30c06436d66652bc2f01ade021592c80a2aad401570a18aa18b82e440d2b9aa1"
 dependencies = [
- "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
 ]
 
 [[package]]
@@ -656,10 +604,8 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
 ]
 
 [[package]]
@@ -668,10 +614,8 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
 dependencies = [
- "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
 ]
 
 [[package]]
@@ -681,30 +625,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
 dependencies = [
  "base16ct",
- "ecdsa",
  "elliptic-curve",
  "primeorder",
- "rand_core",
- "sha2",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
 ]
 
 [[package]]
@@ -854,16 +776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,7 +808,6 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
- "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -960,16 +871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest",
- "rand_core",
-]
-
-[[package]]
 name = "sm2"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,28 +878,6 @@ checksum = "98b22092ef242a118f03ee41dc46b2720c0ca076f544116dbc915cacf532cfaa"
 dependencies = [
  "elliptic-curve",
  "primeorder",
- "rfc6979",
- "signature",
- "sm3",
-]
-
-[[package]]
-name = "sm3"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb9a3b702d0a7e33bc4d85a14456633d2b165c2ad839c5fd9a8417c1ab15860"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -1231,8 +1110,6 @@ checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core",
- "serde",
- "zeroize",
 ]
 
 [[package]]
@@ -1240,17 +1117,3 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -15,17 +15,17 @@ readme = "README.md"
 [dependencies]
 kem = "0.3.0-pre.0"
 rand_core = "0.6.4"
-x25519 = { version = "2.0.1", package = "x25519-dalek", optional = true }
-elliptic-curve = { version = "0.13.8", optional = true }
-bign256 = { version = "0.13.1", optional = true }
-k256 = { version = "0.13.3", optional = true }
-p192 = { version = "0.13.0", optional = true }
-p224 = { version = "0.13.2", optional = true }
-p256 = { version = "0.13.2", optional = true }
-p384 = { version = "0.13.0", optional = true }
-p521 = { version = "0.13.3", optional = true }
-sm2 = { version = "0.13.3", optional = true }
-zeroize = { version = "1.8.1", optional = true }
+x25519 = { version = "2.0.1", package = "x25519-dalek", optional = true, default-features = false }
+elliptic-curve = { version = "0.13.8", optional = true, default-features = false }
+bign256 = { version = "0.13.1", optional = true, default-features = false, features = ["arithmetic"] }
+k256 = { version = "0.13.3", optional = true, default-features = false, features = ["arithmetic"] }
+p192 = { version = "0.13.0", optional = true, default-features = false, features = ["arithmetic"] }
+p224 = { version = "0.13.2", optional = true, default-features = false, features = ["arithmetic"] }
+p256 = { version = "0.13.2", optional = true, default-features = false, features = ["arithmetic"] }
+p384 = { version = "0.13.0", optional = true, default-features = false, features = ["arithmetic"] }
+p521 = { version = "0.13.3", optional = true, default-features = false, features = ["arithmetic"] }
+sm2 = { version = "0.13.3", optional = true, default-features = false, features = ["arithmetic"] }
+zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [features]
 default = ["zeroize"]

--- a/dhkem/src/arithmetic.rs
+++ b/dhkem/src/arithmetic.rs
@@ -1,9 +1,11 @@
 use crate::{DhDecapsulator, DhEncapsulator, DhKem};
-use elliptic_curve::ecdh::{EphemeralSecret, SharedSecret};
-use elliptic_curve::{CurveArithmetic, PublicKey};
+use core::marker::PhantomData;
+use elliptic_curve::{
+    ecdh::{EphemeralSecret, SharedSecret},
+    CurveArithmetic, PublicKey,
+};
 use kem::{Decapsulate, Encapsulate};
 use rand_core::CryptoRngCore;
-use std::marker::PhantomData;
 
 pub struct ArithmeticKem<C: CurveArithmetic>(PhantomData<C>);
 

--- a/dhkem/tests/hpke_p256_test.rs
+++ b/dhkem/tests/hpke_p256_test.rs
@@ -1,4 +1,6 @@
-use crate::{DhKem, NistP256};
+#![cfg(feature = "p256")]
+
+use dhkem::{DhKem, NistP256};
 use elliptic_curve::sec1::ToEncodedPoint;
 use hex_literal::hex;
 use hkdf::Hkdf;
@@ -87,7 +89,7 @@ fn test_dhkem_p256_hkdf_sha256() {
     let (skr, pkr) = NistP256::random_keypair(&mut ConstantRng(&hex!(
         "f3ce7fdae57e1a310d87f1ebbde6f328be0a99cdbcadf4d6589cf29de4b8ffd2"
     )));
-    assert_eq!(pkr.0.to_encoded_point(false).as_bytes(), &pkr_hex);
+    assert_eq!(pkr.to_encoded_point(false).as_bytes(), &pkr_hex);
 
     let (pke, ss1) = pkr
         .encapsulate(&mut ConstantRng(&hex!(

--- a/dhkem/tests/tests.rs
+++ b/dhkem/tests/tests.rs
@@ -1,4 +1,4 @@
-use crate::DhKem;
+use dhkem::DhKem;
 use kem::{Decapsulate, Encapsulate};
 use rand::thread_rng;
 
@@ -41,53 +41,53 @@ where
 #[cfg(feature = "x25519")]
 #[test]
 fn test_x25519() {
-    test_kem::<crate::X25519>();
+    test_kem::<dhkem::X25519>();
 }
 
 #[cfg(feature = "bign256")]
 #[test]
 fn test_bign256() {
-    test_kem::<crate::BignP256>();
+    test_kem::<dhkem::BignP256>();
 }
 
 #[cfg(feature = "k256")]
 #[test]
 fn test_k256() {
-    test_kem::<crate::Secp256k1>();
+    test_kem::<dhkem::Secp256k1>();
 }
 
 #[cfg(feature = "p192")]
 #[test]
 fn test_p192() {
-    test_kem::<crate::NistP192>();
+    test_kem::<dhkem::NistP192>();
 }
 
 #[cfg(feature = "p224")]
 #[test]
 fn test_p224() {
-    test_kem::<crate::NistP224>();
+    test_kem::<dhkem::NistP224>();
 }
 
 #[cfg(feature = "p256")]
 #[test]
 fn test_p256() {
-    test_kem::<crate::NistP256>();
+    test_kem::<dhkem::NistP256>();
 }
 
 #[cfg(feature = "p384")]
 #[test]
 fn test_p384() {
-    test_kem::<crate::NistP384>();
+    test_kem::<dhkem::NistP384>();
 }
 
 #[cfg(feature = "p521")]
 #[test]
 fn test_p521() {
-    test_kem::<crate::NistP521>();
+    test_kem::<dhkem::NistP521>();
 }
 
 #[cfg(feature = "sm2")]
 #[test]
 fn test_sm2() {
-    test_kem::<crate::Sm2>();
+    test_kem::<dhkem::Sm2>();
 }


### PR DESCRIPTION
Adds `no_std` support to `dhkem`, which involved moving `std`-dependent tests from `lib/` to the `tests/` directory, which links them in a separate crate that can access `std`.

Also adds `default-features = false` to each of the elliptic curve crate dependencies.

Finally, adds a CI check that the crate can link on a `no_std` target.