### PR TITLE
ml-kem: re-export `kem` traits and `hybrid-array`

### DIFF
--- a/ml-kem/src/kem.rs
+++ b/ml-kem/src/kem.rs
@@ -8,6 +8,9 @@ use crate::pke::{DecryptionKey, EncryptionKey};
 use crate::util::B32;
 use crate::{Encoded, EncodedSizeUser};
 
+// Re-export traits from the `kem` crate
+pub use ::kem::{Decapsulate, Encapsulate};
+
 /// A shared key resulting from an ML-KEM transaction
 pub(crate) type SharedKey = B32;
 

--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -73,6 +73,8 @@ use hybrid_array::{
 };
 use rand_core::CryptoRngCore;
 
+pub use hybrid_array as array;
+
 #[cfg(feature = "deterministic")]
 pub use util::B32;
 


### PR DESCRIPTION
- Re-exports `kem::{Decapsulate, Encapsulate}` under `kem` module
- Re-exports `hybrid-array` as `array`

Closes #36