### PR TITLE
ml-kem v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "ml-kem"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "crypto-common",

--- a/ml-kem/CHANGELOG.md
+++ b/ml-kem/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2024-08-16)
+### Added
+- `DecapsulationKey::encapsulation_key` ([#48])
+- Re-export `kem::{Decapsulate, Encapsulate}` under `kem` module ([#49])
+- Re-exports `hybrid-array` as `array` ([#49])
+
+### Changed
+- Update to FIPS 203 final ([#47])
+
+[#47]: https://github.com/RustCrypto/KEMs/pull/47
+[#48]: https://github.com/RustCrypto/KEMs/pull/48
+[#49]: https://github.com/RustCrypto/KEMs/pull/49
+
 ## 0.1.1 (2024-06-04)
 ### Security
 - Fix potential "Kyberslash" attack ([#18])
@@ -12,5 +25,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#18]: https://github.com/RustCrypto/KEMs/pull/18
 
 ## 0.1.0 (2024-04-12)
-
 - Initial release

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Module-Lattice-Based Key-Encapsulation Mechanism Standard
 (formerly known as Kyber) as described in FIPS 203
 """
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
### Added
- `DecapsulationKey::encapsulation_key` ([#48])
- Re-export `kem::{Decapsulate, Encapsulate}` under `kem` module ([#49])
- Re-exports `hybrid-array` as `array` ([#49])

### Changed
- Update to FIPS 203 final ([#47])

[#47]: https://github.com/RustCrypto/KEMs/pull/47
[#48]: https://github.com/RustCrypto/KEMs/pull/48
[#49]: https://github.com/RustCrypto/KEMs/pull/49