### PR TITLE
ml_kem: Enable zeroization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
+ "zeroize",
 ]
 
 [[package]]

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -19,12 +19,14 @@ exclude = ["tests/key-gen.rs", "tests/key-gen.json", "tests/encap-decap.rs", "te
 default = ["std"]
 std = ["sha3/std"]
 deterministic = [] # Expose deterministic generation and encapsulation functions
+zeroize = ["dep:zeroize"]
 
 [dependencies]
 kem = "0.3.0-pre.0"
 hybrid-array = { version = "0.2.0-rc.9", features = ["extra-sizes"] }
 rand_core = "0.6.4"
 sha3 = { version = "0.10.8", default-features = false }
+zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/ml-kem/src/algebra.rs
+++ b/ml-kem/src/algebra.rs
@@ -8,7 +8,7 @@ use crate::param::{ArraySize, CbdSamplingSize};
 use crate::util::{Truncate, B32};
 
 #[cfg(feature = "zeroize")]
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::Zeroize;
 
 pub type Integer = u16;
 
@@ -23,9 +23,6 @@ impl Zeroize for FieldElement {
         self.0.zeroize();
     }
 }
-
-#[cfg(feature = "zeroize")]
-impl ZeroizeOnDrop for FieldElement {}
 
 impl FieldElement {
     pub const Q: Integer = 3329;
@@ -195,9 +192,6 @@ impl Zeroize for NttPolynomial {
         }
     }
 }
-
-#[cfg(feature = "zeroize")]
-impl ZeroizeOnDrop for NttPolynomial {}
 
 impl Add<&NttPolynomial> for &NttPolynomial {
     type Output = NttPolynomial;
@@ -446,9 +440,6 @@ where
         }
     }
 }
-
-#[cfg(feature = "zeroize")]
-impl<K> ZeroizeOnDrop for NttVector<K> where K: ArraySize {}
 
 impl<K: ArraySize> Add<&NttVector<K>> for &NttVector<K> {
     type Output = NttVector<K>;

--- a/ml-kem/src/kem.rs
+++ b/ml-kem/src/kem.rs
@@ -30,11 +30,11 @@ where
 }
 
 #[cfg(feature = "zeroize")]
-impl<P> Zeroize for DecapsulationKey<P>
+impl<P> Drop for DecapsulationKey<P>
 where
     P: KemParams,
 {
-    fn zeroize(&mut self) {
+    fn drop(&mut self) {
         self.dk_pke.zeroize();
         self.z.zeroize();
     }

--- a/ml-kem/src/kem.rs
+++ b/ml-kem/src/kem.rs
@@ -8,6 +8,9 @@ use crate::pke::{DecryptionKey, EncryptionKey};
 use crate::util::B32;
 use crate::{Encoded, EncodedSizeUser};
 
+#[cfg(feature = "zeroize")]
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
 // Re-export traits from the `kem` crate
 pub use ::kem::{Decapsulate, Encapsulate};
 
@@ -25,6 +28,20 @@ where
     ek: EncapsulationKey<P>,
     z: B32,
 }
+
+#[cfg(feature = "zeroize")]
+impl<P> Zeroize for DecapsulationKey<P>
+where
+    P: KemParams,
+{
+    fn zeroize(&mut self) {
+        self.dk_pke.zeroize();
+        self.z.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<P> ZeroizeOnDrop for DecapsulationKey<P> where P: KemParams {}
 
 impl<P> EncodedSizeUser for DecapsulationKey<P>
 where

--- a/ml-kem/src/pke.rs
+++ b/ml-kem/src/pke.rs
@@ -7,6 +7,9 @@ use crate::encode::Encode;
 use crate::param::{EncodedCiphertext, EncodedDecryptionKey, EncodedEncryptionKey, PkeParams};
 use crate::util::B32;
 
+#[cfg(feature = "zeroize")]
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
 /// A `DecryptionKey` provides the ability to generate a new key pair, and decrypt an
 /// encrypted value.
 #[derive(Clone, Default, Debug, PartialEq)]
@@ -16,6 +19,19 @@ where
 {
     s_hat: NttVector<P::K>,
 }
+
+#[cfg(feature = "zeroize")]
+impl<P> Zeroize for DecryptionKey<P>
+where
+    P: PkeParams,
+{
+    fn zeroize(&mut self) {
+        self.s_hat.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<P> ZeroizeOnDrop for DecryptionKey<P> where P: PkeParams {}
 
 impl<P> DecryptionKey<P>
 where

--- a/ml-kem/src/pke.rs
+++ b/ml-kem/src/pke.rs
@@ -8,7 +8,7 @@ use crate::param::{EncodedCiphertext, EncodedDecryptionKey, EncodedEncryptionKey
 use crate::util::B32;
 
 #[cfg(feature = "zeroize")]
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::Zeroize;
 
 /// A `DecryptionKey` provides the ability to generate a new key pair, and decrypt an
 /// encrypted value.
@@ -29,9 +29,6 @@ where
         self.s_hat.zeroize();
     }
 }
-
-#[cfg(feature = "zeroize")]
-impl<P> ZeroizeOnDrop for DecryptionKey<P> where P: PkeParams {}
 
 impl<P> DecryptionKey<P>
 where


### PR DESCRIPTION
I'm not totally sure I understand the `zeroize` crate and its sharp edges, but I think this implements zeroization correctly.  Basically just starts at `kem::DecapsulationKey` and works down the stack from there.