### PR TITLE
Fixed ML-KEM benches

### DIFF
--- a/.github/workflows/ml-kem.yml
+++ b/.github/workflows/ml-kem.yml
@@ -64,6 +64,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - run: cargo build --benches
       - run: cargo build --benches --all-features
       - run: cargo test --no-default-features
       - run: cargo test

--- a/ml-kem/benches/mlkem.rs
+++ b/ml-kem/benches/mlkem.rs
@@ -1,47 +1,34 @@
 use ::kem::{Decapsulate, Encapsulate};
 use criterion::{criterion_group, criterion_main, Criterion};
-use crypto_common::rand_core::CryptoRngCore;
-use hybrid_array::{Array, ArraySize};
 use ml_kem::*;
-
-pub fn rand<L: ArraySize>(rng: &mut impl CryptoRngCore) -> Array<u8, L> {
-    let mut val = Array::<u8, L>::default();
-    rng.fill_bytes(&mut val);
-    val
-}
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
-    let d: B32 = rand(&mut rng);
-    let z: B32 = rand(&mut rng);
-    let m: B32 = rand(&mut rng);
-
-    let (dk, ek) = MlKem768::generate_deterministic(&d, &z);
-    let dk_bytes = dk.as_bytes();
-    let ek_bytes = ek.as_bytes();
-    let (ct, _sk) = ek.encapsulate(&mut rng).unwrap();
 
     // Key generation
     c.bench_function("keygen", |b| {
         b.iter(|| {
-            let (dk, ek) = <MlKem768 as KemCore>::generate_deterministic(&d, &z);
+            let (dk, ek) = <MlKem768 as KemCore>::generate(&mut rng);
             let _dk_bytes = dk.as_bytes();
             let _ek_bytes = ek.as_bytes();
         })
     });
 
+    let (dk, ek) = MlKem768::generate(&mut rng);
+    let dk_bytes = dk.as_bytes();
+    let ek_bytes = ek.as_bytes();
+
+    let ek = <MlKem768 as KemCore>::EncapsulationKey::from_bytes(&ek_bytes);
     // Encapsulation
     c.bench_function("encapsulate", |b| {
-        b.iter(|| {
-            let ek = <MlKem768 as KemCore>::EncapsulationKey::from_bytes(&ek_bytes);
-            ek.encapsulate_deterministic(&m).unwrap();
-        })
+        b.iter(|| ek.encapsulate(&mut rng).unwrap())
     });
+    let (ct, _ss) = ek.encapsulate(&mut rng).unwrap();
 
     // Decapsulation
+    let dk = <MlKem768 as KemCore>::DecapsulationKey::from_bytes(&dk_bytes);
     c.bench_function("decapsulate", |b| {
         b.iter(|| {
-            let dk = <MlKem768 as KemCore>::DecapsulationKey::from_bytes(&dk_bytes);
             dk.decapsulate(&ct).unwrap();
         })
     });
@@ -49,7 +36,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     // Round trip
     c.bench_function("round_trip", |b| {
         b.iter(|| {
-            let (dk, ek) = <MlKem768 as KemCore>::generate_deterministic(&d, &z);
+            let (dk, ek) = <MlKem768 as KemCore>::generate(&mut rng);
             let (ct, _sk) = ek.encapsulate(&mut rng).unwrap();
             dk.decapsulate(&ct).unwrap();
         })


### PR DESCRIPTION
Benches weren't compiling. They were using non-public deterministic functions. Now they use the random functions. Also I removed key parsing from the encap and decap functions. IMO they should just be doing encap/decap, but I can add ser/deser back in if you think it really belongs there.