### PR TITLE
Add 'asm' feature flag to ML-KEM

### DIFF
--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -16,8 +16,9 @@ keywords = ["crypto", "kyber", "lattice", "post-quantum"]
 exclude = ["tests/key-gen.rs", "tests/key-gen.json", "tests/encap-decap.rs", "tests/encap-decap.json"]
 
 [features]
-default = ["std"]
+default = ["std", "asm"]
 std = ["sha3/std"]
+asm = ["sha3/asm"]
 deterministic = [] # Expose deterministic generation and encapsulation functions
 zeroize = ["dep:zeroize"]
 


### PR DESCRIPTION
This enables `sha3/asm`. I made it default, but I can make make it not-default if you like.

Criterion tells me (post #55) that this has a -9.5% on runtime for keygen, encap, and decap. This is on my Macbook Air M1