### PR TITLE
ml-kem: bump to v0.3.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "ml-kem"
-version = "0.2.1"
+version = "0.3.0-pre"
 dependencies = [
  "criterion",
  "crypto-common",

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Module-Lattice-Based Key-Encapsulation Mechanism Standard
 (formerly known as Kyber) as described in FIPS 203
 """
-version = "0.2.1"
+version = "0.3.0-pre"
 edition = "2021"
 rust-version = "1.81"
 license = "Apache-2.0 OR MIT"

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -28,7 +28,7 @@ missing_docs = "deny" # Require all public interfaces to be documented
 [dependencies]
 rand_core = { version = "0.6", default-features = false }
 x25519-dalek = { version = "2.0", default-features = false, features = ["static_secrets"] }
-ml-kem = { version = "0.2", default-features = false, features = ["deterministic"], path = "../ml-kem" }
+ml-kem = { version = "=0.3.0-pre", default-features = false, features = ["deterministic"], path = "../ml-kem" }
 sha3 = { version = "0.10", default-features = false }
 kem = "0.3.0-pre.0"
 zeroize = { version = "1.8.1", optional = true, default-features = true, features = ["zeroize_derive"] }


### PR DESCRIPTION
There were breaking changes in #59.

This denotes that a breaking change occurred, however there won't be a release associated with this commit. Instead we'll release a `pre.0` or a v0.3.0 final.