### PR TITLE
Sealed trait to make `(De|En)capsulationKey`s more usable

### DIFF
--- a/ml-kem/src/kem.rs
+++ b/ml-kem/src/kem.rs
@@ -18,12 +18,17 @@ pub use ::kem::{Decapsulate, Encapsulate};
 /// A shared key resulting from an ML-KEM transaction
 pub(crate) type SharedKey = B32;
 
+/// Derived parameters relevant to ML-KEM
+pub trait Params: KemParams {}
+
+impl<K: KemParams> Params for K {}
+
 /// A `DecapsulationKey` provides the ability to generate a new key pair, and decapsulate an
 /// encapsulated shared key.
 #[derive(Clone, Debug, PartialEq)]
 pub struct DecapsulationKey<P>
 where
-    P: KemParams,
+    P: Params,
 {
     dk_pke: DecryptionKey<P>,
     ek: EncapsulationKey<P>,
@@ -147,7 +152,7 @@ where
 #[derive(Clone, Debug, PartialEq)]
 pub struct EncapsulationKey<P>
 where
-    P: KemParams,
+    P: Params,
 {
     ek_pke: EncryptionKey<P>,
     h: B32,
@@ -218,7 +223,7 @@ where
 /// together all of the other related types and sizes.
 pub struct Kem<P>
 where
-    P: KemParams,
+    P: Params,
 {
     _phantom: PhantomData<P>,
 }
@@ -258,7 +263,7 @@ mod test {
 
     fn round_trip_test<P>()
     where
-        P: KemParams,
+        P: Params,
     {
         let mut rng = rand::thread_rng();
 
@@ -279,7 +284,7 @@ mod test {
 
     fn codec_test<P>()
     where
-        P: KemParams,
+        P: Params,
     {
         let mut rng = rand::thread_rng();
         let dk_original = DecapsulationKey::<P>::generate(&mut rng);


### PR DESCRIPTION
Make is possible to wrap `kem::(De|En)capsulationKey` in external packages without exposing `KemParams` publicly.

Instead of making `KemParams` public and allowing external types to implement the interface, I have added a public trait `Params` which has `KemParams` as a public supertrait whose name is not publicly exported (private module). [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed)

This makes it possible to do things like:
```rs
struct WrappedDecapsulationKey<P: Params> {
    key: DecapsulationKey<P>
}
```
This is more convenient than working with `<P as KemCore>::DecapsulationKey`.

Closes #65 