### PR TITLE
CI: always build `frodo-kem` on push

### DIFF
--- a/.github/workflows/frodo-kem.yml
+++ b/.github/workflows/frodo-kem.yml
@@ -8,10 +8,6 @@ on:
       - "Cargo.*"
   push:
     branches: master
-    paths:
-      - ".github/workflows/frodo-kem.yml"
-      - "frodo-kem/**"
-      - "Cargo.*"
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
This follows the configuration of the other crates in the repo