### PR TITLE
frodo-kem: metadata cleanups

### DIFF
--- a/frodo-kem/Cargo.toml
+++ b/frodo-kem/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-authors = ["The RustCrypto Team"]
-categories = ["cryptography"]
-description = "A pure rust implementation of FrodoKEM and eFrodoKEM"
-documentation = "https://docs.rs/frodo-kem"
-edition = "2021"
-exclude = ["tests/**", "bench/**", "examples/**", ".github/**"]
-homepage = "https://github.com/RustCrypto/KEMs"
-keywords = ["quantum", "post", "zero", "knowledge", "encryption"]
-license = "Apache-2.0 OR MIT"
 name = "frodo-kem"
+version = "0.0.0"
+description = "Pure Rust implementation of FrodoKEM and eFrodoKEM"
+authors = ["The RustCrypto Team"]
+documentation = "https://docs.rs/frodo-kem"
+homepage = "https://github.com/RustCrypto/KEMs/tree/master/frodo-kem"
+repository = "https://github.com/RustCrypto/KEMs"
+categories = ["cryptography"]
+keywords = ["quantum", "post", "zero", "knowledge", "encryption"]
+exclude = ["tests/**", "bench/**", "examples/**", ".github/**"]
+license = "Apache-2.0 OR MIT"
 readme = "README.md"
-repository = "https://github.com/RustCrypto/KEMs/frodo-kem"
-version = "0.4.0"
+edition = "2021"
 
 [features]
 default = [

--- a/frodo-kem/README.md
+++ b/frodo-kem/README.md
@@ -3,7 +3,6 @@
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 ![Apache2/MIT licensed][license-image]
-[![Downloads][downloads-image]][crate-link]
 ![build](https://github.com/RustCrypto/KEMs/actions/workflows/frodo-kem.yml/badge.svg)
 ![MSRV][msrv-image]
 
@@ -60,7 +59,7 @@ When in doubt use the FrodoKEM algorithm variants.
 To speed up AES, there are a few options available:
 
 - `RUSTFLAGS="--cfg aes_armv8" cargo build --release` ensures that the ARMv8 AES instructions are used if available.
-- `frodo-kem-rs = { version = "0.3", features = ["openssl"] }` uses the `openssl` crate for AES.
+- `frodo-kem = { version = "0.3", features = ["openssl"] }` uses the `openssl` crate for AES.
 
 By default, the `aes` feature auto-detects the best AES implementation for your platform
 for x86 and x86_64,
@@ -107,10 +106,9 @@ conditions.
 [//]: # (badges)
 
 [RustCrypto]: https://github.com/rustcrypto
-[crate-image]: https://img.shields.io/crates/v/frodo-kem-rs.svg
-[crate-link]: https://crates.io/crates/frodo-kem-rs
-[docs-image]: https://docs.rs/frodo-kem-rs/badge.svg
-[docs-link]: https://docs.rs/frodo-kem-rs/
+[crate-image]: https://img.shields.io/crates/v/frodo-kem.svg?logo=rust
+[crate-link]: https://crates.io/crates/frodo-kem
+[docs-image]: https://docs.rs/frodo-kem/badge.svg
+[docs-link]: https://docs.rs/frodo-kem/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[downloads-image]: https://img.shields.io/crates/d/frodo-kem-rs.svg
 [msrv-image]: https://img.shields.io/badge/rustc-1.82+-blue.svg


### PR DESCRIPTION
- Corrects old links to `frodo-kem-rs` to use new `frodo-kem` name
- Bumps the package version to `0.0.0` since it hasn't been released
- Groups Cargo.toml closer to our other packages