### PR TITLE
clippy: enable `--all-targets`

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -24,8 +24,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.84
         with:
           components: clippy
-      - run: cargo clippy --all-features -- -D warnings
-      # TODO: - run: cargo clippy --all-features --all-targets -- -D warnings
+      - run: cargo clippy --all-features --all-targets -- -D warnings
 
   doc:
     runs-on: ubuntu-latest

--- a/dhkem/tests/hpke_p256_test.rs
+++ b/dhkem/tests/hpke_p256_test.rs
@@ -11,7 +11,7 @@ use sha2::Sha256;
 /// Constant RNG for testing purposes only.
 struct ConstantRng<'a>(pub &'a [u8]);
 
-impl<'a> RngCore for ConstantRng<'a> {
+impl RngCore for ConstantRng<'_> {
     fn next_u32(&mut self) -> u32 {
         let (head, tail) = self.0.split_at(4);
         self.0 = tail;
@@ -58,8 +58,7 @@ fn labeled_expand(prk: &[u8], label: &[u8], info: &[u8], l: u16) -> Vec<u8> {
         info,
     ]
     .concat();
-    let mut out = Vec::with_capacity(l as usize);
-    out.resize(l as usize, 0);
+    let mut out = vec![0; l as usize];
     Hkdf::<Sha256>::from_prk(prk)
         .unwrap()
         .expand(&labeled_info, &mut out)

--- a/frodo-kem/benches/frodo.rs
+++ b/frodo-kem/benches/frodo.rs
@@ -4,7 +4,7 @@ use criterion::{
 use frodo_kem::*;
 use rand_core::SeedableRng;
 
-fn bench_keygen<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
+fn bench_keygen<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
     group.bench_function("KeyGen 640Aes", |b| {
         b.iter(|| {
@@ -43,7 +43,7 @@ fn bench_keygen<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     });
 }
 
-fn bench_encapsulate<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
+fn bench_encapsulate<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
     let (pk, _sk) = Algorithm::FrodoKem640Aes.generate_keypair(&mut rng);
     group.bench_function("Encapsulate 640Aes", |b| {
@@ -100,7 +100,7 @@ fn bench_encapsulate<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     });
 }
 
-fn bench_decapsulate<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
+fn bench_decapsulate<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
     let (pk, sk) = Algorithm::FrodoKem640Aes.generate_keypair(&mut rng);
     let (ct, _ss) = Algorithm::FrodoKem640Aes

--- a/frodo-kem/benches/safe_oqs.rs
+++ b/frodo-kem/benches/safe_oqs.rs
@@ -5,7 +5,7 @@ use criterion::{
 use frodo_kem::*;
 use rand_core::SeedableRng;
 
-fn bench_keygen<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
+fn bench_keygen<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
     group.bench_function("KeyGen 640Aes", |b| {
         b.iter(|| {
@@ -80,7 +80,7 @@ fn bench_keygen<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     });
 }
 
-fn bench_encapsulate<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
+fn bench_encapsulate<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
     let (pk, _sk) = Algorithm::EphemeralFrodoKem640Aes.generate_keypair(&mut rng);
     group.bench_function("Encapsulate 640Aes", |b| {
@@ -179,7 +179,7 @@ fn bench_encapsulate<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     });
 }
 
-fn bench_decapsulate<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
+fn bench_decapsulate<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
     let (pk, sk) = Algorithm::EphemeralFrodoKem640Aes.generate_keypair(&mut rng);
     let (ct, _ss) = Algorithm::EphemeralFrodoKem640Aes

--- a/frodo-kem/src/hazmat.rs
+++ b/frodo-kem/src/hazmat.rs
@@ -26,6 +26,9 @@
 //!
 //! [`FrodoKem640Aes`], [`FrodoKem976Aes`], and [`FrodoKem1344Aes`] for the FrodoKEM-AES algorithms.
 //! [`FrodoKem640Shake`], [`FrodoKem976Shake`], and [`FrodoKem1344Shake`] for the FrodoKEM-SHAKE algorithms.
+
+#![allow(clippy::unwrap_used)]
+
 mod models;
 mod traits;
 
@@ -185,7 +188,7 @@ mod tests {
         assert_eq!(my_ess.as_ref(), my_ss.as_ref());
 
         let their_ct = safe_kem.ciphertext_from_bytes(my_ct.as_ref()).unwrap();
-        let their_ss = safe_kem.decapsulate(&their_sk, &their_ct).unwrap();
+        let their_ss = safe_kem.decapsulate(&their_sk, their_ct).unwrap();
         assert_eq!(my_ess.as_ref(), their_ss.as_ref());
 
         let (their_ct, their_ess) = safe_kem.encapsulate(&their_pk).unwrap();
@@ -235,8 +238,8 @@ mod tests {
         let their_pk = opt_pk.unwrap();
         let their_sk = opt_sk.unwrap();
 
-        let (ciphertext, pk_ss) = kem.encapsulate(&their_pk).unwrap();
-        let sk_ss = kem.decapsulate(&their_sk, &ciphertext).unwrap();
+        let (ciphertext, pk_ss) = kem.encapsulate(their_pk).unwrap();
+        let sk_ss = kem.decapsulate(their_sk, &ciphertext).unwrap();
         assert_eq!(pk_ss.as_ref(), sk_ss.as_ref());
     }
 
@@ -280,7 +283,7 @@ mod tests {
         let opt_ct = safe_kem.ciphertext_from_bytes(&our_ciphertext.0);
         assert!(opt_ct.is_some());
         let ct = opt_ct.unwrap();
-        let res_ss = safe_kem.decapsulate(&their_sk, &ct);
+        let res_ss = safe_kem.decapsulate(their_sk, ct);
         assert!(res_ss.is_ok());
         let their = res_ss.unwrap();
         assert_eq!(our_ss.as_ref(), their.as_ref());
@@ -327,7 +330,7 @@ mod tests {
         let (opt_ss, _) = kem.decapsulate(&our_sk, &our_ciphertext);
         assert_eq!(opt_ss.as_ref(), our_ss.as_ref());
 
-        let (their_ct, their_ss) = safe_kem.encapsulate(&their_pk).unwrap();
+        let (their_ct, their_ss) = safe_kem.encapsulate(their_pk).unwrap();
         let res_my_ciphertext = Ciphertext::from_slice(their_ct.as_ref());
         assert!(res_my_ciphertext.is_ok());
         let my_ciphertext = res_my_ciphertext.unwrap();

--- a/frodo-kem/src/lib.rs
+++ b/frodo-kem/src/lib.rs
@@ -1624,6 +1624,7 @@ fn ct_eq_bytes(lhs: &[u8], rhs: &[u8]) -> Choice {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use rand_core::{RngCore, SeedableRng};
@@ -1655,18 +1656,18 @@ mod tests {
 
         let mut mu = vec![0u8; alg.params().message_length];
         rng.fill_bytes(&mut mu);
-        let (our_ct, our_ess) = alg.encapsulate(&our_pk, &mu, &[]).unwrap();
+        let (our_ct, our_ess) = alg.encapsulate(&our_pk, &mu, []).unwrap();
         let (our_dss, mu_prime) = alg.decapsulate(&our_sk, &our_ct).unwrap();
         assert_eq!(our_ess.value, our_dss.value);
         assert_eq!(mu, mu_prime);
 
         let their_ct = kem.ciphertext_from_bytes(&our_ct.value).unwrap();
-        let their_ss = kem.decapsulate(&their_sk, &their_ct).unwrap();
+        let their_ss = kem.decapsulate(their_sk, their_ct).unwrap();
         assert_eq!(our_dss.value, their_ss.as_ref());
 
-        let (their_ct, their_ess) = kem.encapsulate(&their_pk).unwrap();
+        let (their_ct, their_ess) = kem.encapsulate(their_pk).unwrap();
 
-        let our_ct = alg.ciphertext_from_bytes(&their_ct.as_ref()).unwrap();
+        let our_ct = alg.ciphertext_from_bytes(their_ct.as_ref()).unwrap();
 
         let (their_dss, _) = alg.decapsulate(&our_sk, &our_ct).unwrap();
         assert_eq!(their_ess.as_ref(), their_dss.value);

--- a/ml-kem/src/algebra.rs
+++ b/ml-kem/src/algebra.rs
@@ -541,6 +541,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::cast_possible_truncation)]
     fn polynomial_ops() {
         let f = Polynomial(Array::from_fn(|i| FieldElement(i as Integer)));
         let g = Polynomial(Array::from_fn(|i| FieldElement(2 * i as Integer)));
@@ -551,6 +552,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::similar_names)]
     fn ntt() {
         let f = Polynomial(Array::from_fn(|i| FieldElement(i as Integer)));
         let g = Polynomial(Array::from_fn(|i| FieldElement(2 * i as Integer)));
@@ -643,7 +645,7 @@ mod test {
     // for k in $-\eta, \ldots, \eta$.  The cases of interest here are \eta = 2, 3.
     type Distribution = [f64; Q_SIZE];
     const Q_SIZE: usize = FieldElement::Q as usize;
-    const CBD2: Distribution = {
+    static CBD2: Distribution = {
         let mut dist = [0.0; Q_SIZE];
         dist[Q_SIZE - 2] = 1.0 / 16.0;
         dist[Q_SIZE - 1] = 4.0 / 16.0;
@@ -652,7 +654,7 @@ mod test {
         dist[2] = 1.0 / 16.0;
         dist
     };
-    const CBD3: Distribution = {
+    static CBD3: Distribution = {
         let mut dist = [0.0; Q_SIZE];
         dist[Q_SIZE - 3] = 1.0 / 64.0;
         dist[Q_SIZE - 2] = 6.0 / 64.0;
@@ -663,7 +665,7 @@ mod test {
         dist[3] = 1.0 / 64.0;
         dist
     };
-    const UNIFORM: Distribution = [1.0 / (FieldElement::Q as f64); Q_SIZE];
+    static UNIFORM: Distribution = [1.0 / (FieldElement::Q as f64); Q_SIZE];
 
     fn kl_divergence(p: &Distribution, q: &Distribution) -> f64 {
         p.iter()
@@ -672,6 +674,7 @@ mod test {
             .sum()
     }
 
+    #[allow(clippy::cast_precision_loss, clippy::large_stack_arrays)]
     fn test_sample(sample: &[FieldElement], ref_dist: &Distribution) {
         // Verify data and compute the empirical distribution
         let mut sample_dist: Distribution = [0.0; Q_SIZE];
@@ -688,6 +691,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::cast_possible_truncation)]
     fn sample_uniform() {
         // We require roughly Q/2 samples to verify the uniform distribution.  This is because for
         // M < N, the uniform distribution over a subset of M elements has KL distance:

--- a/ml-kem/src/compress.rs
+++ b/ml-kem/src/compress.rs
@@ -92,11 +92,13 @@ pub(crate) mod test {
     use hybrid_array::typenum::{U1, U10, U11, U12, U4, U5, U6};
     use num_rational::Ratio;
 
+    #[allow(clippy::cast_possible_truncation)]
     fn rational_compress<D: CompressionFactor>(input: u16) -> u16 {
         let fraction = Ratio::new(u32::from(input) * (1 << D::USIZE), FieldElement::Q32);
         (fraction.round().to_integer() as u16) & D::MASK
     }
 
+    #[allow(clippy::cast_possible_truncation)]
     fn rational_decompress<D: CompressionFactor>(input: u16) -> u16 {
         let fraction = Ratio::new(u32::from(input) * FieldElement::Q32, 1 << D::USIZE);
         fraction.round().to_integer() as u16
@@ -106,7 +108,7 @@ pub(crate) mod test {
     #[allow(clippy::integer_division_remainder_used)]
     fn compression_decompression_inequality<D: CompressionFactor>() {
         const QI32: i32 = FieldElement::Q as i32;
-        let error_threshold = Ratio::new(FieldElement::Q, 1 << D::USIZE).to_integer() as i32;
+        let error_threshold = i32::from(Ratio::new(FieldElement::Q, 1 << D::USIZE).to_integer());
 
         for x in 0..FieldElement::Q {
             let mut y = FieldElement(x);

--- a/ml-kem/src/encode.rs
+++ b/ml-kem/src/encode.rs
@@ -172,20 +172,20 @@ pub(crate) mod test {
     }
 
     #[allow(clippy::integer_division_remainder_used)]
-    fn byte_codec_test<D>(decoded: DecodedValue, encoded: EncodedPolynomial<D>)
+    fn byte_codec_test<D>(decoded: &DecodedValue, encoded: &EncodedPolynomial<D>)
     where
         D: EncodingSize,
     {
         // Test known answer
-        let actual_encoded = byte_encode::<D>(&decoded);
-        assert_eq!(actual_encoded, encoded);
+        let actual_encoded = byte_encode::<D>(decoded);
+        assert_eq!(&actual_encoded, encoded);
 
-        let actual_decoded = byte_decode::<D>(&encoded);
-        assert_eq!(actual_decoded, decoded);
+        let actual_decoded = byte_decode::<D>(encoded);
+        assert_eq!(&actual_decoded, decoded);
 
         // Test random decode/encode and encode/decode round trips
         let mut rng = rand::thread_rng();
-        let mut decoded: Array<Integer, U256> = Default::default();
+        let mut decoded: Array<Integer, U256> = Array::default();
         rng.fill(decoded.as_mut_slice());
         let m = match D::USIZE {
             12 => FieldElement::Q,
@@ -206,7 +206,7 @@ pub(crate) mod test {
         // The 1-bit can only represent decoded values equal to 0 or 1.
         let decoded: DecodedValue = Array::<_, U2>([FieldElement(0), FieldElement(1)]).repeat();
         let encoded: EncodedPolynomial<U1> = Array([0xaa; 32]);
-        byte_codec_test::<U1>(decoded, encoded);
+        byte_codec_test::<U1>(&decoded, &encoded);
 
         // For other codec widths, we use a standard sequence
         let decoded: DecodedValue = Array::<_, U8>([
@@ -222,31 +222,31 @@ pub(crate) mod test {
         .repeat();
 
         let encoded: EncodedPolynomial<U4> = Array::<_, U4>([0x10, 0x32, 0x54, 0x76]).repeat();
-        byte_codec_test::<U4>(decoded, encoded);
+        byte_codec_test::<U4>(&decoded, &encoded);
 
         let encoded: EncodedPolynomial<U5> =
             Array::<_, U5>([0x20, 0x88, 0x41, 0x8a, 0x39]).repeat();
-        byte_codec_test::<U5>(decoded, encoded);
+        byte_codec_test::<U5>(&decoded, &encoded);
 
         let encoded: EncodedPolynomial<U6> =
             Array::<_, U6>([0x40, 0x20, 0x0c, 0x44, 0x61, 0x1c]).repeat();
-        byte_codec_test::<U6>(decoded, encoded);
+        byte_codec_test::<U6>(&decoded, &encoded);
 
         let encoded: EncodedPolynomial<U10> =
             Array::<_, U10>([0x00, 0x04, 0x20, 0xc0, 0x00, 0x04, 0x14, 0x60, 0xc0, 0x01]).repeat();
-        byte_codec_test::<U10>(decoded, encoded);
+        byte_codec_test::<U10>(&decoded, &encoded);
 
         let encoded: EncodedPolynomial<U11> = Array::<_, U11>([
             0x00, 0x08, 0x80, 0x00, 0x06, 0x40, 0x80, 0x02, 0x18, 0xe0, 0x00,
         ])
         .repeat();
-        byte_codec_test::<U11>(decoded, encoded);
+        byte_codec_test::<U11>(&decoded, &encoded);
 
         let encoded: EncodedPolynomial<U12> = Array::<_, U12>([
             0x00, 0x10, 0x00, 0x02, 0x30, 0x00, 0x04, 0x50, 0x00, 0x06, 0x70, 0x00,
         ])
         .repeat();
-        byte_codec_test::<U12>(decoded, encoded);
+        byte_codec_test::<U12>(&decoded, &encoded);
     }
 
     #[allow(clippy::integer_division_remainder_used)]
@@ -260,16 +260,16 @@ pub(crate) mod test {
         assert_eq!(actual_decoded, decoded);
     }
 
-    fn vector_codec_known_answer_test<D, T>(decoded: T, encoded: Array<u8, T::EncodedSize>)
+    fn vector_codec_known_answer_test<D, T>(decoded: &T, encoded: &Array<u8, T::EncodedSize>)
     where
         D: EncodingSize,
         T: Encode<D> + PartialEq + Debug,
     {
         let actual_encoded = decoded.encode();
-        assert_eq!(actual_encoded, encoded);
+        assert_eq!(&actual_encoded, encoded);
 
-        let actual_decoded: T = Encode::decode(&encoded);
-        assert_eq!(actual_decoded, decoded);
+        let actual_decoded: T = Encode::decode(encoded);
+        assert_eq!(&actual_decoded, decoded);
     }
 
     #[test]
@@ -292,16 +292,16 @@ pub(crate) mod test {
         let decoded: PolynomialVector<U2> = PolynomialVector(Array([poly, poly]));
         let encoded: EncodedPolynomialVector<U5, U2> =
             Array::<_, U5>([0x20, 0x88, 0x41, 0x8a, 0x39]).repeat();
-        vector_codec_known_answer_test::<U5, PolynomialVector<U2>>(decoded, encoded);
+        vector_codec_known_answer_test::<U5, PolynomialVector<U2>>(&decoded, &encoded);
 
         let decoded: PolynomialVector<U3> = PolynomialVector(Array([poly, poly, poly]));
         let encoded: EncodedPolynomialVector<U5, U3> =
             Array::<_, U5>([0x20, 0x88, 0x41, 0x8a, 0x39]).repeat();
-        vector_codec_known_answer_test::<U5, PolynomialVector<U3>>(decoded, encoded);
+        vector_codec_known_answer_test::<U5, PolynomialVector<U3>>(&decoded, &encoded);
 
         let decoded: PolynomialVector<U4> = PolynomialVector(Array([poly, poly, poly, poly]));
         let encoded: EncodedPolynomialVector<U5, U4> =
             Array::<_, U5>([0x20, 0x88, 0x41, 0x8a, 0x39]).repeat();
-        vector_codec_known_answer_test::<U5, PolynomialVector<U4>>(decoded, encoded);
+        vector_codec_known_answer_test::<U5, PolynomialVector<U4>>(&decoded, &encoded);
     }
 }

--- a/x-wing/src/lib.rs
+++ b/x-wing/src/lib.rs
@@ -346,7 +346,7 @@ mod tests {
 
     impl CryptoRng for SeedRng {}
 
-    /// Test with test vectors from: https://github.com/dconnolly/draft-connolly-cfrg-xwing-kem/blob/main/spec/test-vectors.json
+    /// Test with test vectors from: <https://github.com/dconnolly/draft-connolly-cfrg-xwing-kem/blob/main/spec/test-vectors.json>
     #[test]
     fn rfc_test_vectors() {
         let test_vectors =
@@ -398,7 +398,7 @@ mod tests {
         let sk_bytes = sk.as_bytes();
         let pk_bytes = pk.as_bytes();
 
-        let sk_b = DecapsulationKey::from(sk_bytes.clone());
+        let sk_b = DecapsulationKey::from(*sk_bytes);
         let pk_b = EncapsulationKey::from(&pk_bytes.clone());
 
         assert!(sk == sk_b);


### PR DESCRIPTION
Notably this also runs clippy on test cases.

For now the violations which couldn't be fixed automatically with `--fix` have been annotated with `allow`, but in the future the code could be improved.