### PR TITLE
frodo-kem: use `set-msrv` in CI

### DIFF
--- a/.github/workflows/frodo-kem.yml
+++ b/.github/workflows/frodo-kem.yml
@@ -22,25 +22,42 @@ defaults:
     shell: bash
 
 jobs:
+  set-msrv:
+    uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
+    with:
+      msrv: 1.82.0
+
   build:
+    needs: set-msrv
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - ${{ needs.set-msrv.outputs.msrv }}
+          - stable
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
       - run: cargo build --no-default-features --features=frodo
       - run: cargo build --no-default-features --features=efrodo
       - run: cargo build --no-default-features || [ $? -eq 101 ]
       - run: cargo build --all-features
 
   test:
+    needs: set-msrv
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - ${{ needs.set-msrv.outputs.msrv }}
+          - stable
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
       - run: cargo build --all-features --benches --release --keep-going
       - run: cargo test --all-features --release
       - run: cargo test --no-default-features --features=frodo,efrodo,serde --release

--- a/frodo-kem/Cargo.toml
+++ b/frodo-kem/Cargo.toml
@@ -12,6 +12,7 @@ exclude = ["tests/**", "bench/**", "examples/**", ".github/**"]
 license = "Apache-2.0 OR MIT"
 readme = "README.md"
 edition = "2021"
+rust-version = "1.82"
 
 [features]
 default = [


### PR DESCRIPTION
We previously weren't testing on MSRV.

This uses `set-msrv` + a CI matrix with `stable` to do that, which also clears the way towards running `cross`