### PR TITLE
x-wing: use `rand::rngs::OsRng` in code example

### DIFF
--- a/x-wing/src/lib.rs
+++ b/x-wing/src/lib.rs
@@ -14,16 +14,12 @@
 //! decapsulation key. X-Wing-KEM is a general-purpose hybrid post-quantum KEM, combining x25519 and ML-KEM-768.
 //!
 //! ```
-//! # use rand;
-//! # use kem::{Decapsulate, Encapsulate};
-//! let mut rng = rand::thread_rng();
+//! use kem::{Decapsulate, Encapsulate};
 //!
-//! let (sk, pk) = x_wing::generate_key_pair(&mut rng);
-//!
-//! let (ct, ss_sender) = pk.encapsulate(&mut rng).unwrap();
-//!
+//! let mut rng = &mut rand::rngs::OsRng;
+//! let (sk, pk) = x_wing::generate_key_pair(rng);
+//! let (ct, ss_sender) = pk.encapsulate(rng).unwrap();
 //! let ss_receiver = sk.decapsulate(&ct).unwrap();
-//!
 //! assert_eq!(ss_sender, ss_receiver);
 //! ```
 


### PR DESCRIPTION
This is the most conservative choice for a random number generator for keygen, which is a thin wrapper for the `getrandom` crate, which gets randomness directly from the OS.

Also removes superfluous newlines in the example, and makes the imported traits explicit so the code example is complete.