### PR TITLE
Add generate_key_pair_derand to XWing

### DIFF
--- a/x-wing/src/lib.rs
+++ b/x-wing/src/lib.rs
@@ -257,6 +257,15 @@ pub fn generate_key_pair<R: CryptoRng + ?Sized>(
     (sk, pk)
 }
 
+/// Generate a X-Wing key pair deterministically.
+pub fn generate_key_pair_derand(
+    sk: [u8; DECAPSULATION_KEY_SIZE],
+) -> (DecapsulationKey, EncapsulationKey) {
+    let sk = DecapsulationKey::generate_derand(sk);
+    let pk = sk.encapsulation_key();
+    (sk, pk)
+}
+
 fn combiner(
     ss_m: &B32,
     ss_x: &x25519_dalek::SharedSecret,
@@ -353,8 +362,7 @@ mod tests {
     }
 
     fn run_test(test_vector: TestVector) {
-        let mut seed = SeedRng::new(test_vector.seed);
-        let (sk, pk) = generate_key_pair(&mut seed);
+        let (sk, pk) = generate_key_pair_derand(test_vector.seed.try_into().unwrap());
 
         assert_eq!(sk.as_bytes(), &test_vector.sk);
         assert_eq!(&pk.to_bytes(), test_vector.pk.as_slice());


### PR DESCRIPTION
The [X-wing draft](https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/) specifies the option generateKeyPairDerand as a deterministic way to generate xwing keys. While this is usually only reserved for tests, it is also required to implement HPKE.

> For testing, it is convenient to have a deterministic version of key
   generation.  An X-Wing implementation MAY provide the following
   derandomized variant of key generation.
   
```
def GenerateKeyPairDerand(sk):
  sk_M, sk_X, pk_M, pk_X = expandDecapsulationKey(sk)
  return sk, concat(pk_M, pk_X)
```
> sk must be 32 bytes.
> GenerateKeyPairDerand() returns the 32 byte secret encapsulation key sk and the 1216 byte decapsulation key pk.

Then later, to implement HPKE:
```
def DeriveKeyPair(ikm):
   # Extract 32-byte seed from variable-length ikm using SHAKE.
   sk = SHAKE256(ikm, 32*8)
   return GenerateKeyPairDerand(sk)
```

So, to implement HPKE using XWing, we need `GenerateKeyPairDerand` to be publicly exposed. I realize this is also possible via defining a custom `SeedableRng` in the tests, but I don't think this should be used or expected as the public API contract.

Let me know if we need to add more warnings around this function, since users should in most cases not use the derand version.