### PR TITLE
implement zeroize on DecapsulationKey

### DIFF
--- a/ml-kem/src/kem.rs
+++ b/ml-kem/src/kem.rs
@@ -31,13 +31,23 @@ where
 }
 
 #[cfg(feature = "zeroize")]
+impl<P> Zeroize for DecapsulationKey<P>
+where
+    P: KemParams,
+{
+    fn zeroize(&mut self) {
+        self.dk_pke.zeroize();
+        self.z.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
 impl<P> Drop for DecapsulationKey<P>
 where
     P: KemParams,
 {
     fn drop(&mut self) {
-        self.dk_pke.zeroize();
-        self.z.zeroize();
+        self.zeroize();
     }
 }
 


### PR DESCRIPTION
Added an implementation of `Zeroize` in `DecapsulationKey` instead of just `ZeroizeOnDrop`. 

This is useful for wrapping `DecapsulationKey` with a [`secrecy::SecretBox`](https://docs.rs/secrecy/0.10.3/secrecy/struct.SecretBox.html) and seems to have no down-side.

Using a `SecretBox` is still useful even if the inner-type implements `ZeroizeOnDrop` since I want to force using the `ExposeSecret` trait to access the `DecapsulationKey`.

Let me know if I can do anything to help this get merged, thank you!