### PR TITLE
ml-kem: minimum viable seed support for `DecapsulationKey`

### DIFF
--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -69,7 +69,7 @@ use ::kem::{Decapsulate, Encapsulate};
 use core::fmt::Debug;
 use hybrid_array::{
     Array,
-    typenum::{U2, U3, U4, U5, U10, U11},
+    typenum::{U2, U3, U4, U5, U10, U11, U64},
 };
 use rand_core::CryptoRng;
 
@@ -79,6 +79,10 @@ pub use hybrid_array as array;
 pub use util::B32;
 
 pub use param::{ArraySize, ParameterSet};
+
+/// ML-KEM seeds are decapsulation (private) keys, which are consistently 64-bytes across all
+/// security levels, and are the preferred serialization for representing such keys.
+pub type Seed = Array<u8, U64>;
 
 /// An object that knows what size it is
 pub trait EncodedSizeUser {
@@ -148,8 +152,7 @@ pub trait KemCore: Clone {
 
     /// Generate a new (decapsulation, encapsulation) key pair deterministically
     #[cfg(feature = "deterministic")]
-    fn generate_deterministic(d: &B32, z: &B32)
-    -> (Self::DecapsulationKey, Self::EncapsulationKey);
+    fn generate_deterministic(d: B32, z: B32) -> (Self::DecapsulationKey, Self::EncapsulationKey);
 }
 
 /// `MlKem512` is the parameter set for security category 1, corresponding to key search on a block

--- a/ml-kem/tests/key-gen.rs
+++ b/ml-kem/tests/key-gen.rs
@@ -34,7 +34,7 @@ fn verify<K: KemCore>(tc: &acvp::TestCase) {
     let dk_bytes = Encoded::<K::DecapsulationKey>::try_from(tc.dk.as_slice()).unwrap();
     let ek_bytes = Encoded::<K::EncapsulationKey>::try_from(tc.ek.as_slice()).unwrap();
 
-    let (dk, ek) = K::generate_deterministic(&d, &z);
+    let (dk, ek) = K::generate_deterministic(d, z);
 
     // Verify correctness via serialization
     assert_eq!(dk.as_bytes().as_slice(), tc.dk.as_slice());

--- a/x-wing/src/lib.rs
+++ b/x-wing/src/lib.rs
@@ -180,7 +180,7 @@ impl DecapsulationKey {
 
         let d = read_from(&mut expanded).into();
         let z = read_from(&mut expanded).into();
-        let (sk_m, pk_m) = MlKem768::generate_deterministic(&d, &z);
+        let (sk_m, pk_m) = MlKem768::generate_deterministic(d, z);
 
         let sk_x = read_from(&mut expanded);
         let sk_x = StaticSecret::from(sk_x);


### PR DESCRIPTION
- Adds a `Seed` type alias for `Array<u8, U64>`
- Adds infallible `DecapsulationKey::from_seed`
- Adds fallible `DecapsulationKey::to_seed` returning an `Option` to handle the case that the key was initialized from the expanded form. This involved optionally carrying the original `d` as an optional struct member of `DecapsulationKey`.

Additional notes:
- Seed-related functionality is not gated under the `deterministic` feature. That feature should possibly be changed to only feature-gate deterministic encryption.
- None of the existing APIs for handling the expanded form have been updated to disambiguate them, e.g. `from_expanded_bytes`, though they probably should be, as well as potentially being feature gated (if we got rid of them entirely, `to_seed` could be infallible).
- Another way to make `to_seed` infallible would be an `ExpandedDecapsulationKey` type which holds everything but `d`, with `DecapsulationKey` being a newtype that carries `d`.
- `ml-kem` should probably adopt `subtle` to replace the built-in constant-time code and do constant-time comparisons of private keys, as noted in a TODO.

Closes #53 