### PR TITLE
ml-kem: use `subtle`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4aae35a0fcbe22ff1be50fe96df72002d5a4a6fb4aae9193cf2da0daa36da2"
+checksum = "dac89f8a64533a9b0eaa73a68e424db0fb1fd6271c74cc0125336a05f090568d"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -698,10 +698,11 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.0"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe39a812f039072707ce38020acbab2f769087952eddd9e2b890f37654b2349"
+checksum = "f471e0a81b2f90ffc0cb2f951ae04da57de8baa46fa99112b062a5173a5088d0"
 dependencies = [
+ "subtle",
  "typenum",
  "zeroize",
 ]
@@ -866,6 +867,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
+ "subtle",
  "zeroize",
 ]
 

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -21,9 +21,10 @@ zeroize = ["dep:zeroize"]
 
 [dependencies]
 kem = "0.3.0-pre.0"
-hybrid-array = { version = "0.4", features = ["extra-sizes"] }
+hybrid-array = { version = "0.4.4", features = ["extra-sizes", "subtle"] }
 rand_core = "0.9"
 sha3 = { version = "0.11.0-rc.0", default-features = false }
+subtle = { version = "2", default-features = false }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/ml-kem/src/algebra.rs
+++ b/ml-kem/src/algebra.rs
@@ -1,6 +1,7 @@
 use core::ops::{Add, Mul, Sub};
 use hybrid_array::{Array, typenum::U256};
 use sha3::digest::XofReader;
+use subtle::{Choice, ConstantTimeEq};
 
 use crate::crypto::{PRF, PrfOutput, XOF};
 use crate::encode::Encode;
@@ -16,6 +17,12 @@ pub type Integer = u16;
 /// can defer modular reductions.
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct FieldElement(pub Integer);
+
+impl ConstantTimeEq for FieldElement {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.ct_eq(&other.0)
+    }
+}
 
 #[cfg(feature = "zeroize")]
 impl Zeroize for FieldElement {
@@ -179,6 +186,12 @@ impl<K: ArraySize> PolynomialVector<K> {
 /// An element of the ring `T_q`, i.e., a tuple of 128 elements of the direct sum components of `T_q`.
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct NttPolynomial(pub Array<FieldElement, U256>);
+
+impl ConstantTimeEq for NttPolynomial {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.ct_eq(&other.0)
+    }
+}
 
 #[cfg(feature = "zeroize")]
 impl Zeroize for NttPolynomial {
@@ -422,6 +435,12 @@ impl<K: ArraySize> NttVector<K> {
             let mut xof = XOF(rho, j.truncate(), i.truncate());
             NttPolynomial::sample_uniform(&mut xof)
         }))
+    }
+}
+
+impl<K: ArraySize> ConstantTimeEq for NttVector<K> {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.ct_eq(&other.0)
     }
 }
 

--- a/ml-kem/src/pke.rs
+++ b/ml-kem/src/pke.rs
@@ -1,4 +1,5 @@
 use hybrid_array::typenum::{U1, Unsigned};
+use subtle::{Choice, ConstantTimeEq};
 
 use crate::algebra::{NttMatrix, NttVector, Polynomial, PolynomialVector};
 use crate::compress::Compress;
@@ -12,12 +13,31 @@ use zeroize::Zeroize;
 
 /// A `DecryptionKey` provides the ability to generate a new key pair, and decrypt an
 /// encrypted value.
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug)]
 pub struct DecryptionKey<P>
 where
     P: PkeParams,
 {
     s_hat: NttVector<P::K>,
+}
+
+impl<P> ConstantTimeEq for DecryptionKey<P>
+where
+    P: PkeParams,
+{
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.s_hat.ct_eq(&other.s_hat)
+    }
+}
+
+// Handwritten to ensure a constant time comparison is performed
+impl<P> PartialEq for DecryptionKey<P>
+where
+    P: PkeParams,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).into()
+    }
 }
 
 #[cfg(feature = "zeroize")]


### PR DESCRIPTION
- Replaces `constant_time_eq` and handwritten constant time selection with `subtle::ConstantTimeEq` and `ConditionalSelect`
- Uses `ConstantTimeEq` when comparing `DecryptionKey`s