### PR TITLE
ml-kem: remove `pkcs8::PrivateKeyChoice`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,20 +406,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7050e8041c28720851f7db83183195b6acf375bb7bb28e3b86f0fe6cbd69459d"
 dependencies = [
  "const-oid",
- "der_derive",
  "pem-rfc7468",
  "zeroize",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.8.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be645fee2afe89d293b96c19e4456e6ac69520fc9c6b8a58298550138e361ffe"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -875,7 +863,6 @@ version = "0.3.0-pre"
 dependencies = [
  "const-oid",
  "criterion",
- "der",
  "hex",
  "hex-literal",
  "hybrid-array",

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -20,7 +20,7 @@ alloc = ["pkcs8?/alloc"]
 
 deterministic = [] # Expose deterministic encapsulation functions
 pem = ["pkcs8/pem"]
-pkcs8 = ["dep:const-oid", "dep:der", "dep:pkcs8"]
+pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 zeroize = ["dep:zeroize"]
 
 [dependencies]
@@ -31,7 +31,6 @@ sha3 = { version = "0.11.0-rc.0", default-features = false }
 subtle = { version = "2", default-features = false }
 
 # optional dependencies
-der = { version = "0.8.0-rc.0", optional = true, default-features = false, features = ["derive"] }
 const-oid = { version = "0.10.1", optional = true, default-features = false, features = ["db"] }
 pkcs8 = { version = "0.11.0-rc.4", optional = true, default-features = false }
 zeroize = { version = "1.8.1", optional = true, default-features = false }

--- a/ml-kem/src/kem.rs
+++ b/ml-kem/src/kem.rs
@@ -140,8 +140,7 @@ where
     /// This value is key material. Please treat it with care.
     ///
     /// # Returns
-    /// - `Some` if the [`DecapsulationKey`] was initialized using `from_seed`, `generate`, or
-    ///   `generate_deterministic`
+    /// - `Some` if the [`DecapsulationKey`] was initialized using `from_seed` or `generate`.
     /// - `None` if the [`DecapsulationKey`] was initialized from the expanded form.
     #[inline]
     pub fn to_seed(&self) -> Option<Seed> {

--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -65,7 +65,6 @@ pub mod kem;
 /// Section 7. Parameter Sets
 mod param;
 
-/// PKCS#8 encoding support
 pub mod pkcs8;
 
 /// Trait definitions


### PR DESCRIPTION
Since we only implement support for seeds in PKCS#8 (for now), this type is no longer necessary, and removing it allows us to drop a dependency on `der_derive` (which in turn pulls in the proc macro stack e.g. `syn`)