### PR TITLE
ml-kem v0.3.0-pre.0 (aborted)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,7 +859,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "ml-kem"
-version = "0.3.0-pre"
+version = "0.3.0-pre.0"
 dependencies = [
  "const-oid",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ members = [
 debug = true
 
 [patch.crates-io]
+ml-kem = { path = "./ml-kem" }
+
 elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
 kem = { git = "https://github.com/RustCrypto/traits.git" }
 

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Module-Lattice-Based Key-Encapsulation Mechanism Standard
 (formerly known as Kyber) as described in FIPS 203
 """
-version = "0.3.0-pre"
+version = "0.3.0-pre.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -17,11 +17,11 @@ os_rng = ["rand_core/os_rng"]
 zeroize = ["dep:zeroize", "ml-kem/zeroize", "x25519-dalek/zeroize"]
 
 [dependencies]
-rand_core = { version = "0.9.3", default-features = false }
-x25519-dalek = { version = "=3.0.0-pre.0", default-features = false, features = ["static_secrets"] }
-ml-kem = { version = "=0.3.0-pre", default-features = false, features = ["deterministic"], path = "../ml-kem" }
-sha3 = { version = "0.11.0-rc.0", default-features = false }
 kem = "0.3.0-pre.0"
+ml-kem = { version = "=0.3.0-pre.0", default-features = false, features = ["deterministic"] }
+rand_core = { version = "0.9.3", default-features = false }
+sha3 = { version = "0.11.0-rc.0", default-features = false }
+x25519-dalek = { version = "=3.0.0-pre.0", default-features = false, features = ["static_secrets"] }
 zeroize = { version = "1.8.1", optional = true, default-features = true, features = ["zeroize_derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
I couldn't actually publish:

```
error[E0643]: method `encapsulate` has incompatible signature for trait
   --> src/kem.rs:221:20
    |
221 |     fn encapsulate<R: CryptoRng + ?Sized>(
    |                    ^ expected `impl Trait`, found generic parameter
    |
   ::: /Users/tony/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/kem-0.3.0-pre.0/src/lib.rs:23:37
    |
23  |     fn encapsulate(&self, rng: &mut impl CryptoRngCore) -> Result<(EK, SS), Self::Error>;
```

Seems we need to do another `kem` crate release