### PR TITLE
dhkem: use `rc.0` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,9 +337,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c069823f41bdc75e99546bfd59eb1ed27d69dc720e5c949fe502b82926f8448"
+checksum = "7f4b0fda9462026d53a3ef37c5ec283639ee8494a1a5401109c0e2a3fb4d490c"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7050e8041c28720851f7db83183195b6acf375bb7bb28e3b86f0fe6cbd69459d"
+checksum = "e9d8dd2f26c86b27a2a8ea2767ec7f9df7a89516e4794e54ac01ee618dda3aa4"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -449,8 +449,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.12"
-source = "git+https://github.com/RustCrypto/traits.git#501b8854593a440a08fcb299a1ae421b16c76169"
+version = "0.14.0-rc.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cbb5fbebc360d8631bb2e0c0e2617e9141e32825c54547b982509c6ad8de87"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -677,18 +678,18 @@ checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hkdf"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6738bc5110ee31b066339f0c9454db29a93db3b0484bbf2afa8a7e9cebc62141"
+checksum = "d8ef30358b03ca095a5b910547f4f8d4b9f163e4057669c5233ef595b1ecf008"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc6a2fcc35ab09136c6df2cdf9ca49790701420a3a6b5db0987dddbabc79b21"
+checksum = "a3fd4dc94c318c1ede8a2a48341c250d6ddecd3ba793da2820301a9f92417ad9"
 dependencies = [
  "digest",
 ]
@@ -770,8 +771,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-pre.9"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#4cd8bde360c6b1c75cba4ec11c3be1772ad96b16"
+version = "0.14.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c566022f1abac5de18bdbd126ff463783cf41da8adfb6523ae3f4e46fc90d4"
 dependencies = [
  "cfg-if",
  "elliptic-curve",
@@ -954,8 +956,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-pre.9"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#4cd8bde360c6b1c75cba4ec11c3be1772ad96b16"
+version = "0.14.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a35f78d0f5ae56f424c09bcb08444b56569e351084421b0def687800c17560c"
 dependencies = [
  "elliptic-curve",
  "primefield",
@@ -964,18 +967,21 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-pre.9"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#4cd8bde360c6b1c75cba4ec11c3be1772ad96b16"
+version = "0.14.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83ae3cc685c1f06b8df2cabb5101eef0116c4a36a413ee7d3403cfc0f0fc7323"
 dependencies = [
  "elliptic-curve",
+ "fiat-crypto",
  "primefield",
  "primeorder",
 ]
 
 [[package]]
 name = "p521"
-version = "0.14.0-pre.9"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#4cd8bde360c6b1c75cba4ec11c3be1772ad96b16"
+version = "0.14.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70c973d55b113ae8afe9565bcdecd6ba2484baa7eadca3e64874bfa908dc8d8b"
 dependencies = [
  "base16ct",
  "elliptic-curve",
@@ -1006,9 +1012,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.6"
+version = "0.11.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53e5d0804fa4070b1b2a5b320102f2c1c094920a7533d5d87c2630609bcbd34"
+checksum = "93eac55f10aceed84769df670ea4a32d2ffad7399400d41ee1c13b1cd8e1b478"
 dependencies = [
  "der",
  "spki",
@@ -1082,8 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-pre.4"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#4cd8bde360c6b1c75cba4ec11c3be1772ad96b16"
+version = "0.14.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a69250bb6fddbe7936a87b22a1c62174b980acbf9f5ad8ef937e4f1e74349f"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -1094,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-pre.7"
+version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af12dd34fc62d04416de85af032f4595369437fb7b0143d36ae60cecaf5cdddf"
+checksum = "36714e8f5443e0cc1497f71972788dd95f75bf7253a4393c9f33f3ff9f556cc9"
 dependencies = [
  "elliptic-curve",
 ]
@@ -1322,9 +1329,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.9"
+version = "0.8.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e67a3c9fb9a8f065af9fa30d65812fcc16a66cbf911eff1f6946957ce48f16"
+checksum = "1dff52f6118bc9f0ac974a54a639d499ac26a6cad7a6e39bc0990c19625e793b"
 dependencies = [
  "base16ct",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,3 @@ debug = true
 
 [patch.crates-io]
 ml-kem = { path = "./ml-kem" }
-
-elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
-primefield = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
-k256 = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
-p256 = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
-p384 = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
-p521 = { git = "https://github.com/RustCrypto/elliptic-curves.git" }

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -18,11 +18,11 @@ kem = "=0.3.0-pre.1"
 rand_core = "0.9.0"
 
 # optional dependencies
-elliptic-curve = { version = "0.14.0-rc.12", optional = true, default-features = false }
-k256 = { version = "0.14.0-pre.5", optional = true, default-features = false, features = ["arithmetic"] }
-p256 = { version = "0.14.0-pre.5", optional = true, default-features = false, features = ["arithmetic"] }
-p384 = { version = "0.14.0-pre.5", optional = true, default-features = false, features = ["arithmetic"] }
-p521 = { version = "0.14.0-pre.5", optional = true, default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.16", optional = true, default-features = false }
+k256 = { version = "0.14.0-rc.0", optional = true, default-features = false, features = ["arithmetic"] }
+p256 = { version = "0.14.0-rc.0", optional = true, default-features = false, features = ["arithmetic"] }
+p384 = { version = "0.14.0-rc.0", optional = true, default-features = false, features = ["arithmetic"] }
+p521 = { version = "0.14.0-rc.0", optional = true, default-features = false, features = ["arithmetic"] }
 x25519 = { version = "=3.0.0-pre.0", package = "x25519-dalek", optional = true, default-features = false }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 

--- a/ml-kem/src/pkcs8.rs
+++ b/ml-kem/src/pkcs8.rs
@@ -40,7 +40,7 @@ use {
 const SEED_TAG_NUMBER: TagNumber = TagNumber(0);
 
 /// ML-KEM seed serialized as ASN.1.
-type SeedString<'o> = ContextSpecific<OctetStringRef<'o>>;
+type SeedString<'a> = ContextSpecific<&'a OctetStringRef>;
 
 impl AssociatedOid for MlKem512Params {
     const OID: ::pkcs8::ObjectIdentifier = const_oid::db::fips203::ID_ALG_ML_KEM_512;

--- a/ml-kem/tests/pkcs8.rs
+++ b/ml-kem/tests/pkcs8.rs
@@ -14,7 +14,7 @@ use pkcs8::{
 use rand_core::CryptoRng;
 
 /// ML-KEM seed serialized as ASN.1.
-type SeedString<'o> = ContextSpecific<OctetStringRef<'o>>;
+type SeedString<'a> = ContextSpecific<&'a OctetStringRef>;
 
 fn der_serialization_and_deserialization<K>(expected_encaps_len: u32)
 where


### PR DESCRIPTION
Updates to use all of the latest `rc.0` crate releases