### PR TITLE
Remove `rustfmt.toml` files

### DIFF
--- a/frodo-kem/rustfmt.toml
+++ b/frodo-kem/rustfmt.toml
@@ -1,5 +1,0 @@
-newline_style = "Unix"
-use_field_init_shorthand = true
-reorder_imports = true
-reorder_modules = true
-reorder_impl_items = true

--- a/x-wing/rustfmt.toml
+++ b/x-wing/rustfmt.toml
@@ -1,8 +1,0 @@
-# Take a preview on the style of https://rust-lang.github.io/rfcs/3309-style-team.html
-
-# The default setting now is to order the imports blocks alphabetically.
-# The setting will combine the blocks, split them in std, external and crate and order them alphabetically.
-group_imports = "StdExternalCrate"
-
-# Combine the import per module inplace of the default of do nothing.
-imports_granularity = "Module"


### PR DESCRIPTION
Instead uses the default settings