### PR TITLE
Bump `kem` to v0.4.0-pre.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "kem"
-version = "0.3.0-pre.2"
+version = "0.4.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4701a9c37a0843da68e19189250e8c62276fb551fe55bde787e9da480c45ee59"
+checksum = "c1ec5336e2804a5746a2cf0575537afae902c0a29e82c542918b4c5adf392456"
 dependencies = [
  "rand_core",
  "zeroize",

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["crypto", "ecdh", "ecc"]
 readme = "README.md"
 
 [dependencies]
-kem = "=0.3.0-pre.2"
+kem = "=0.4.0-pre.0"
 rand_core = "0.9.0"
 
 # optional dependencies

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -24,7 +24,7 @@ pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 zeroize = ["dep:zeroize"]
 
 [dependencies]
-kem = "=0.3.0-pre.2"
+kem = "=0.4.0-pre.0"
 hybrid-array = { version = "0.4.4", features = ["extra-sizes", "subtle"] }
 rand_core = "0.9"
 sha3 = { version = "0.11.0-rc.0", default-features = false }

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -17,7 +17,7 @@ os_rng = ["rand_core/os_rng"]
 zeroize = ["dep:zeroize", "ml-kem/zeroize", "x25519-dalek/zeroize"]
 
 [dependencies]
-kem = "=0.3.0-pre.2"
+kem = "=0.4.0-pre.0"
 ml-kem = { version = "=0.3.0-pre.1", default-features = false, features = ["deterministic"] }
 rand_core = { version = "0.9.3", default-features = false }
 sha3 = { version = "0.11.0-rc.0", default-features = false }


### PR DESCRIPTION
The minor version was bumped to avoid breaking previous releases of `ml-kem`. See: #153