### PR TITLE
ml-kem: add `DecapsulationKey::from_expanded`

### DIFF
--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -88,7 +88,7 @@ pub use util::B32;
 pub use ml_kem_512::MlKem512Params;
 pub use ml_kem_768::MlKem768Params;
 pub use ml_kem_1024::MlKem1024Params;
-pub use param::{ArraySize, ParameterSet};
+pub use param::{ArraySize, ExpandedDecapsulationKey, ParameterSet};
 pub use traits::*;
 
 /// ML-KEM seeds are decapsulation (private) keys, which are consistently 64-bytes across all

--- a/ml-kem/src/param.rs
+++ b/ml-kem/src/param.rs
@@ -26,6 +26,9 @@ use crate::algebra::{FieldElement, NttVector};
 use crate::encode::Encode;
 use crate::util::{B32, Flatten, Unflatten};
 
+#[cfg(doc)]
+use crate::Seed;
+
 /// An array length with other useful properties
 pub trait ArraySize: hybrid_array::ArraySize + PartialEq + Debug {}
 
@@ -241,10 +244,10 @@ pub trait KemParams: PkeParams {
         ek: EncodedEncryptionKey<Self>,
         h: B32,
         z: B32,
-    ) -> EncodedDecapsulationKey<Self>;
+    ) -> ExpandedDecapsulationKey<Self>;
 
     fn split_dk(
-        enc: &EncodedDecapsulationKey<Self>,
+        enc: &ExpandedDecapsulationKey<Self>,
     ) -> (
         &EncodedDecryptionKey<Self>,
         &EncodedEncryptionKey<Self>,
@@ -256,7 +259,8 @@ pub trait KemParams: PkeParams {
 pub type DecapsulationKeySize<P> = <P as KemParams>::DecapsulationKeySize;
 pub type EncapsulationKeySize<P> = <P as PkeParams>::EncryptionKeySize;
 
-pub type EncodedDecapsulationKey<P> = Array<u8, <P as KemParams>::DecapsulationKeySize>;
+/// Serialized decapsulation key after having been expanded from a [`Seed`].
+pub type ExpandedDecapsulationKey<P> = Array<u8, <P as KemParams>::DecapsulationKeySize>;
 
 impl<P> KemParams for P
 where
@@ -276,13 +280,13 @@ where
         ek: EncodedEncryptionKey<Self>,
         h: B32,
         z: B32,
-    ) -> EncodedDecapsulationKey<Self> {
+    ) -> ExpandedDecapsulationKey<Self> {
         dk.concat(ek).concat(h).concat(z)
     }
 
     #[allow(clippy::similar_names)] // allow dk_pke, ek_pke, following the spec
     fn split_dk(
-        enc: &EncodedDecapsulationKey<Self>,
+        enc: &ExpandedDecapsulationKey<Self>,
     ) -> (
         &EncodedDecryptionKey<Self>,
         &EncodedEncryptionKey<Self>,


### PR DESCRIPTION
This is intended to subsume the uses of the `EncodedSizeUser` trait, providing a way for users who insist on using the expanded key format to be able to initialize `DecapsulationKey`s.

To deter its use, it's marked as deprecated. Many implementations have opted not to support it at all, and in the future we can potentially consider removing it (which would allow `to_seed` to be infallible).

After this, it should be possible to deprecate `EncodedSizeUser` as well, and remove it in a future release.