### PR TITLE
Bump `rand_core` to v0.10.0-rc-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4838e4ad37bb032dea137f441d5f71c16c26c068af512e64c5bc13a88cdfc7"
+checksum = "fd9e1c818b25efb32214df89b0ec22f01aa397aaeb718d1022bf0635a3bfd1a8"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -79,7 +79,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -160,6 +160,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3585020fc6766ef7ff5c58d69819dbca16a19008ae347bb5d3e4e145c495eb38"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,10 +200,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd4ef774202f1749465fc7cf88d70fc30620e8cacd5429268f4bff7d003bd976"
+checksum = "155e4a260750fa4f7754649f049748aacc31db238a358d85fd721002f230f92f"
 dependencies = [
+ "block-buffer",
  "crypto-common",
  "inout",
 ]
@@ -264,25 +277,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -290,12 +300,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -337,9 +347,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.9"
+version = "0.7.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4b0fda9462026d53a3ef37c5ec283639ee8494a1a5401109c0e2a3fb4d490c"
+checksum = "6715836b4946e8585016e80b79c7561476aff3b22f7b756778e7b109d86086c6"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -350,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
+checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
 dependencies = [
  "hybrid-array",
  "rand_core",
@@ -376,9 +386,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.0"
+version = "5.0.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdebdcbeb8f27a33dd326d0c6382a475a838abbb306bfd573b79d5e39be7afd3"
+checksum = "6f9200d1d13637f15a6acb71e758f64624048d85b31a5fdbfd8eca1e2687d0b7"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -432,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac89f8a64533a9b0eaa73a68e424db0fb1fd6271c74cc0125336a05f090568d"
+checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -451,8 +461,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cbb5fbebc360d8631bb2e0c0e2617e9141e32825c54547b982509c6ad8de87"
+source = "git+https://github.com/RustCrypto/traits#bd85081709e127b9fa9f885d38252a649f85b581"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -492,14 +501,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "ff"
 version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
+source = "git+https://github.com/tarcieri/ff?branch=rand_core%2Fv0.10.0-rc-2#470e52fa35f7f6cb59f1f005003a14ac50b50cfd"
 dependencies = [
  "rand_core",
  "subtle",
@@ -517,12 +525,13 @@ version = "0.0.1"
 dependencies = [
  "aes",
  "bincode",
+ "chacha20",
  "criterion",
  "hex",
  "hybrid-array",
  "openssl-sys",
  "postcard",
- "rand_chacha",
+ "rand",
  "rand_core",
  "rstest",
  "safe-oqs",
@@ -603,8 +612,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 [[package]]
 name = "group"
 version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
+source = "git+https://github.com/tarcieri/group?branch=rand_core%2Fv0.10.0-rc-2#50640b46d5f7eff37aee24d76e991c18444f372e"
 dependencies = [
  "ff",
  "rand_core",
@@ -638,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heapless"
@@ -655,12 +663,6 @@ dependencies = [
  "spin",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -679,18 +681,18 @@ checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hkdf"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ef30358b03ca095a5b910547f4f8d4b9f163e4057669c5233ef595b1ecf008"
+checksum = "cfbb4225acf2b5cc4e12d384672cd6d1f0cb980ff5859ffcf144db25b593a24d"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3fd4dc94c318c1ede8a2a48341c250d6ddecd3ba793da2820301a9f92417ad9"
+checksum = "f1c597ac7d6cc8143e30e83ef70915e7f883b18d8bec2e2b2bce47f5bbb06d57"
 dependencies = [
  "digest",
 ]
@@ -701,7 +703,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -717,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -727,22 +729,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-rc.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1603f76010ff924b616c8f44815a42eb10fb0b93d308b41deaa8da6d4251fd4b"
+checksum = "c7357b6e7aa75618c7864ebd0634b115a7218b0615f4cb1df33ac3eca23943d4"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -750,6 +741,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -782,18 +782,18 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.2.0-pre.0"
+version = "0.2.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
+checksum = "3d546793a04a1d3049bd192856f804cfe96356e2cf36b54b4e575155babe9f41"
 dependencies = [
  "cpufeatures",
 ]
 
 [[package]]
 name = "kem"
-version = "0.4.0-pre.1"
+version = "0.4.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5b5199da7d6db120ea6d910c82c83e7b49ccf87c6f64c1069d334e60eadbe1"
+checksum = "66d92f9203b5234ec3bb463e4a743960b04e0ac171af3e50fb66f2874ffab24c"
 dependencies = [
  "crypto-common",
  "rand_core",
@@ -959,8 +959,7 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.14.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a35f78d0f5ae56f424c09bcb08444b56569e351084421b0def687800c17560c"
+source = "git+https://github.com/RustCrypto/elliptic-curves#c145e37a3cdd16e0903295b2b91e48fdbda11943"
 dependencies = [
  "elliptic-curve",
  "primefield",
@@ -1014,9 +1013,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.7"
+version = "0.11.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93eac55f10aceed84769df670ea4a32d2ffad7399400d41ee1c13b1cd8e1b478"
+checksum = "77089aec8290d0b7bb01b671b091095cf1937670725af4fd73d47249f03b12c0"
 dependencies = [
  "der",
  "spki",
@@ -1070,15 +1069,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,8 +1081,7 @@ dependencies = [
 [[package]]
 name = "primefield"
 version = "0.14.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a69250bb6fddbe7936a87b22a1c62174b980acbf9f5ad8ef937e4f1e74349f"
+source = "git+https://github.com/RustCrypto/elliptic-curves#c145e37a3cdd16e0903295b2b91e48fdbda11943"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -1139,32 +1128,20 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.10.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "9e7d245ced4538f0406b1579d3d4a6515a2ff1bdf20733492e2e4fc90a648769"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.10.0-rc-2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom",
-]
+checksum = "104a23e4e8b77312a823b6b5613edbac78397e2f34320bc7ac4277013ec4478e"
 
 [[package]]
 name = "rayon"
@@ -1275,7 +1252,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1350,10 +1327,11 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -1377,10 +1355,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.217"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1401,11 +1388,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1433,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
+checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1444,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e6a92fd180fd205defdc0b78288ce847c7309d329fd6647a814567e67db50e"
+checksum = "2103ca0e6f4e9505eae906de5e5883e06fc3b2232fb5d6914890c7bbcb62f478"
 dependencies = [
  "digest",
  "keccak",
@@ -1541,14 +1528,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.7.3",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -1556,8 +1546,14 @@ name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1567,11 +1563,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.8",
  "winnow",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "typenum"
@@ -1702,16 +1711,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1789,9 +1789,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
@@ -1809,6 +1809,7 @@ dependencies = [
 name = "x-wing"
 version = "0.1.0-pre.2"
 dependencies = [
+ "getrandom",
  "hex",
  "kem",
  "ml-kem",
@@ -1823,34 +1824,12 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "3.0.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2a76f35d0d6fa96ffc48330f09dc230cd6bdc118b0fce43c25085ced5d72c6b"
+version = "3.0.0-pre.1"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek?branch=rand_core%2Fv0.10-rc#a5872540830ef9d51bc2ef0ec53d2268895802a3"
 dependencies = [
  "curve25519-dalek",
  "rand_core",
  "zeroize",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,10 @@ debug = true
 
 [patch.crates-io]
 ml-kem = { path = "./ml-kem" }
+
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
+ff = { git = "https://github.com/tarcieri/ff", branch = "rand_core/v0.10.0-rc-2" }
+group = { git = "https://github.com/tarcieri/group", branch = "rand_core/v0.10.0-rc-2" }
+p256 = { git = "https://github.com/RustCrypto/elliptic-curves " }
+primefield = { git = "https://github.com/RustCrypto/elliptic-curves " }
+x25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek", branch = "rand_core/v0.10-rc" }

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["crypto", "ecdh", "ecc"]
 readme = "README.md"
 
 [dependencies]
-kem = "=0.4.0-pre.1"
-rand_core = "0.9.0"
+kem = "=0.4.0-pre.2"
+rand_core = "0.10.0-rc-2"
 
 # optional dependencies
 elliptic-curve = { version = "0.14.0-rc.16", optional = true, default-features = false }
@@ -23,8 +23,14 @@ k256 = { version = "0.14.0-rc.0", optional = true, default-features = false, fea
 p256 = { version = "0.14.0-rc.0", optional = true, default-features = false, features = ["arithmetic"] }
 p384 = { version = "0.14.0-rc.0", optional = true, default-features = false, features = ["arithmetic"] }
 p521 = { version = "0.14.0-rc.0", optional = true, default-features = false, features = ["arithmetic"] }
-x25519 = { version = "=3.0.0-pre.0", package = "x25519-dalek", optional = true, default-features = false }
+x25519 = { version = "=3.0.0-pre.1", package = "x25519-dalek", optional = true, default-features = false }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
+
+[dev-dependencies]
+hex-literal = "1"
+hkdf = "0.13.0-rc.3"
+rand = "0.10.0-rc.1"
+sha2 = "0.11.0-rc.3"
 
 [features]
 default = ["zeroize"]
@@ -35,12 +41,6 @@ p384 = ["dep:p384", "ecdh"]
 p521 = ["dep:p521", "ecdh"]
 x25519 = ["dep:x25519", "x25519/reusable_secrets"]
 zeroize = ["dep:zeroize"]
-
-[dev-dependencies]
-hex-literal = "1"
-hkdf = "0.13.0-rc.0"
-rand = "0.9.2"
-sha2 = "0.11.0-rc.2"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/frodo-kem/Cargo.toml
+++ b/frodo-kem/Cargo.toml
@@ -55,17 +55,17 @@ openssl-shake = ["dep:openssl-sys"]
 serde = ["dep:hex", "dep:serde"]
 
 [dependencies]
-aes = { version = "0.9.0-rc.0", optional = true }
+aes = { version = "0.9.0-rc.2", optional = true }
 hex = { version = "0.4", optional = true }
 openssl-sys = { version = "0.9.104", optional = true }
-rand_core = { version = "0.9", features = [] }
+rand_core = { version = "0.10.0-rc-2", features = [] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serdect = "0.4"
 subtle = "2.6"
 thiserror = "2.0"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
-sha3 = { version = "0.11.0-rc.0", features = ["asm"] }
+sha3 = { version = "0.11.0-rc.3", features = ["asm"] }
 zeroize = { version = "1", features = ["aarch64"] }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
@@ -78,13 +78,13 @@ sha3 = { version = "0.11.0-rc.0" }
 zeroize = "1"
 
 [dev-dependencies]
-aes = "0.9.0-rc.0"
+aes = "0.9.0-rc.2"
 bincode = "1.3"
-criterion = "0.5"
+criterion = "0.7"
 hex = "0.4"
 hybrid-array = "0.4"
-rand_core = { version = "0.9", features = ["os_rng"] }
-rand_chacha = "0.9"
+rand = "0.10.0-rc.1"
+chacha20 = "0.10.0-rc.3"
 rstest = "0.26"
 safe-oqs = { version = "0.10", default-features = false, features = ["frodokem"] }
 postcard = { version = "1.0", features = ["use-std"] }
@@ -92,7 +92,7 @@ serde_bare = "0.5"
 serde_cbor = "0.11"
 serde_json = "1.0"
 serde_yaml = "0.9"
-toml = "0.8"
+toml = "0.9"
 
 [package.metadata.docs.rs]
 features = [

--- a/frodo-kem/benches/frodo.rs
+++ b/frodo-kem/benches/frodo.rs
@@ -5,7 +5,7 @@ use frodo_kem::*;
 use rand_core::SeedableRng;
 
 fn bench_keygen<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let mut rng = rand_chacha::ChaCha8Rng::from_os_rng();
+    let mut rng = chacha20::ChaCha8Rng::seed_from_u64(42);
     group.bench_function("KeyGen 640Aes", |b| {
         b.iter(|| {
             let (_pk, _sk) = Algorithm::FrodoKem640Aes.generate_keypair(&mut rng);
@@ -44,7 +44,7 @@ fn bench_keygen<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 }
 
 fn bench_encapsulate<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let mut rng = rand_chacha::ChaCha8Rng::from_os_rng();
+    let mut rng = chacha20::ChaCha8Rng::seed_from_u64(42);
     let (pk, _sk) = Algorithm::FrodoKem640Aes.generate_keypair(&mut rng);
     group.bench_function("Encapsulate 640Aes", |b| {
         b.iter(|| {
@@ -101,7 +101,7 @@ fn bench_encapsulate<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 }
 
 fn bench_decapsulate<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let mut rng = rand_chacha::ChaCha8Rng::from_os_rng();
+    let mut rng = chacha20::ChaCha8Rng::seed_from_u64(42);
     let (pk, sk) = Algorithm::FrodoKem640Aes.generate_keypair(&mut rng);
     let (ct, _ss) = Algorithm::FrodoKem640Aes
         .encapsulate_with_rng(&pk, &mut rng)

--- a/frodo-kem/benches/safe_oqs.rs
+++ b/frodo-kem/benches/safe_oqs.rs
@@ -6,7 +6,7 @@ use frodo_kem::*;
 use rand_core::SeedableRng;
 
 fn bench_keygen<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let mut rng = rand_chacha::ChaCha8Rng::from_os_rng();
+    let mut rng = chacha20::ChaCha8Rng::seed_from_u64(42);
     group.bench_function("KeyGen 640Aes", |b| {
         b.iter(|| {
             let (_pk, _sk) = Algorithm::EphemeralFrodoKem640Aes.generate_keypair(&mut rng);
@@ -81,7 +81,7 @@ fn bench_keygen<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 }
 
 fn bench_encapsulate<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let mut rng = rand_chacha::ChaCha8Rng::from_os_rng();
+    let mut rng = chacha20::ChaCha8Rng::seed_from_u64(42);
     let (pk, _sk) = Algorithm::EphemeralFrodoKem640Aes.generate_keypair(&mut rng);
     group.bench_function("Encapsulate 640Aes", |b| {
         b.iter(|| {
@@ -180,7 +180,7 @@ fn bench_encapsulate<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 }
 
 fn bench_decapsulate<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let mut rng = rand_chacha::ChaCha8Rng::from_os_rng();
+    let mut rng = chacha20::ChaCha8Rng::seed_from_u64(42);
     let (pk, sk) = Algorithm::EphemeralFrodoKem640Aes.generate_keypair(&mut rng);
     let (ct, _ss) = Algorithm::EphemeralFrodoKem640Aes
         .encapsulate_with_rng(&pk, &mut rng)

--- a/frodo-kem/src/hazmat.rs
+++ b/frodo-kem/src/hazmat.rs
@@ -181,7 +181,7 @@ mod tests {
         let my_pk = EncryptionKey::<F>::from_slice(their_pk.as_ref()).unwrap();
         let my_sk = DecryptionKey::<F>::from_slice(their_sk.as_ref()).unwrap();
 
-        let mut rng = rand_chacha::ChaCha8Rng::from_seed([1u8; 32]);
+        let mut rng = chacha20::ChaCha8Rng::from_seed([1u8; 32]);
 
         let (my_ct, my_ess) = kem.encapsulate_with_rng(&my_pk, &mut rng);
         let (my_ss, _) = kem.decapsulate(&my_sk, &my_ct);
@@ -227,7 +227,7 @@ mod tests {
         #[case] kem: F,
         #[case] alg: safe_oqs::kem::Algorithm,
     ) {
-        let mut rng = rand_chacha::ChaCha8Rng::from_seed([1u8; 32]);
+        let mut rng = chacha20::ChaCha8Rng::from_seed([1u8; 32]);
         let (our_pk, our_sk) = kem.generate_keypair(&mut rng);
         let kem = safe_oqs::kem::Kem::new(alg).unwrap();
         let opt_pk = kem.public_key_from_bytes(&our_pk.0);
@@ -269,7 +269,7 @@ mod tests {
         safe_oqs::kem::Algorithm::FrodoKem1344Shake
     )]
     fn encapsulate_compatibility<F: Kem>(#[case] kem: F, #[case] alg: safe_oqs::kem::Algorithm) {
-        let mut rng = rand_chacha::ChaCha8Rng::from_seed([1u8; 32]);
+        let mut rng = chacha20::ChaCha8Rng::from_seed([1u8; 32]);
         let (our_pk, our_sk) = kem.generate_keypair(&mut rng);
         let safe_kem = safe_oqs::kem::Kem::new(alg).unwrap();
 
@@ -315,7 +315,7 @@ mod tests {
         safe_oqs::kem::Algorithm::FrodoKem1344Shake
     )]
     fn decapsulate_compatibility<F: Kem>(#[case] kem: F, #[case] alg: safe_oqs::kem::Algorithm) {
-        let mut rng = rand_chacha::ChaCha8Rng::from_seed([1u8; 32]);
+        let mut rng = chacha20::ChaCha8Rng::from_seed([1u8; 32]);
         let (our_pk, our_sk) = kem.generate_keypair(&mut rng);
         let safe_kem = safe_oqs::kem::Kem::new(alg).unwrap();
 

--- a/frodo-kem/src/lib.rs
+++ b/frodo-kem/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ```
 //! use frodo_kem::Algorithm;
-//! use rand_core::{OsRng, TryRngCore};
+//! use rand::{rngs::OsRng, TryRngCore};
 //!
 //! let mut rng = OsRng.unwrap_err();
 //! let alg = Algorithm::FrodoKem640Shake;
@@ -28,7 +28,7 @@
 //!
 //! ```
 //! use frodo_kem::Algorithm;
-//! use rand_core::{RngCore, OsRng, TryRngCore};
+//! use rand::{rngs::OsRng, RngCore, TryRngCore};
 //!
 //! let mut rng = OsRng.unwrap_err();
 //! let alg = Algorithm::FrodoKem1344Shake;
@@ -1647,7 +1647,7 @@ mod tests {
         kem::Algorithm::FrodoKem1344Shake
     )]
     fn ephemeral_works(#[case] alg: Algorithm, #[case] safe_alg: kem::Algorithm) {
-        let mut rng = rand_chacha::ChaCha8Rng::from_seed([1u8; 32]);
+        let mut rng = chacha20::ChaCha8Rng::from_seed([1u8; 32]);
         let (our_pk, our_sk) = alg.generate_keypair(&mut rng);
         let kem = kem::Kem::new(safe_alg).unwrap();
 
@@ -1686,7 +1686,7 @@ mod tests {
     #[case::shake976(Algorithm::FrodoKem976Shake)]
     #[case::shake1344(Algorithm::FrodoKem1344Shake)]
     fn works(#[case] alg: Algorithm) {
-        let mut rng = rand_chacha::ChaCha8Rng::from_seed([1u8; 32]);
+        let mut rng = chacha20::ChaCha8Rng::from_seed([1u8; 32]);
         let (our_pk, our_sk) = alg.generate_keypair(&mut rng);
 
         let mut mu = vec![0u8; alg.params().message_length];
@@ -1716,7 +1716,7 @@ mod tests {
             #[case::shake976(Algorithm::EphemeralFrodoKem976Shake)]
             #[case::shake1344(Algorithm::EphemeralFrodoKem1344Shake)]
             fn $name(#[case] alg: Algorithm) {
-                let mut rng = rand_chacha::ChaCha8Rng::from_seed([3u8; 32]);
+                let mut rng = chacha20::ChaCha8Rng::from_seed([3u8; 32]);
                 let (pk, sk) = alg.generate_keypair(&mut rng);
                 let (ct, ss) = alg.encapsulate_with_rng(&pk, &mut rng).unwrap();
 

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -24,23 +24,23 @@ pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 zeroize = ["dep:zeroize"]
 
 [dependencies]
-kem = "=0.4.0-pre.1"
+kem = "=0.4.0-pre.2"
 hybrid-array = { version = "0.4.4", features = ["extra-sizes", "subtle"] }
-rand_core = "0.9"
-sha3 = { version = "0.11.0-rc.0", default-features = false }
+rand_core = "0.10.0-rc-2"
+sha3 = { version = "0.11.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
 
 # optional dependencies
 const-oid = { version = "0.10.1", optional = true, default-features = false, features = ["db"] }
-pkcs8 = { version = "0.11.0-rc.4", optional = true, default-features = false }
+pkcs8 = { version = "0.11.0-rc.8", optional = true, default-features = false }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
-criterion = "0.5.1"
+criterion = "0.7"
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "1"
 num-rational = { version = "0.4.2", default-features = false, features = ["num-bigint"] }
-rand = "0.9"
+rand = "0.10.0-rc.1"
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.125"
 

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -13,23 +13,26 @@ keywords = ["crypto", "x-wing", "xwing", "kem", "post-quantum"]
 exclude = ["src/test-vectors.json"]
 
 [features]
-os_rng = ["rand_core/os_rng"]
+getrandom = ["dep:getrandom"]
 zeroize = ["dep:zeroize", "ml-kem/zeroize", "x25519-dalek/zeroize"]
 
 [dependencies]
-kem = "=0.4.0-pre.1"
+kem = "=0.4.0-pre.2"
 ml-kem = { version = "=0.3.0-pre.2", default-features = false, features = ["deterministic"] }
-rand_core = { version = "0.9.3", default-features = false }
-sha3 = { version = "0.11.0-rc.0", default-features = false }
-x25519-dalek = { version = "=3.0.0-pre.0", default-features = false, features = ["static_secrets"] }
+rand_core = { version = "0.10.0-rc-2", default-features = false }
+sha3 = { version = "0.11.0-rc.3", default-features = false }
+x25519-dalek = { version = "=3.0.0-pre.1", default-features = false, features = ["static_secrets"] }
+
+# optional dependencies
+getrandom = { version = "0.3", optional = true }
 zeroize = { version = "1.8.1", optional = true, default-features = true, features = ["zeroize_derive"] }
 
 [dev-dependencies]
-rand_core = { version = "0.9" }
+rand_core = { version = "0.10.0-rc-2" }
 hex = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rand = "0.9"
+rand = "0.10.0-rc.1"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This also accordingly bumps all of the underlying crates to versions which (transitively) depend on the `rand`/`rand_core` v0.10 release series