### PR TITLE
Remove `bincode` dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,15 +62,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,7 +428,6 @@ name = "frodo-kem"
 version = "0.0.1"
 dependencies = [
  "aes",
- "bincode",
  "chacha20",
  "criterion",
  "hex",

--- a/frodo-kem/Cargo.toml
+++ b/frodo-kem/Cargo.toml
@@ -79,7 +79,6 @@ zeroize = "1"
 
 [dev-dependencies]
 aes = "0.9.0-rc.2"
-bincode = "1.3"
 criterion = "0.7"
 hex = "0.4"
 hybrid-array = "0.4"

--- a/frodo-kem/README.md
+++ b/frodo-kem/README.md
@@ -73,7 +73,6 @@ On Armv8, the rust shake implementation is faster than the openssl implementatio
 This crate has been tested against the following `serde` compatible formats:
 
 - [x] serde_bare
-- [x] bincode
 - [x] postcard
 - [x] serde_cbor
 - [x] serde_json

--- a/frodo-kem/src/lib.rs
+++ b/frodo-kem/src/lib.rs
@@ -1741,9 +1741,4 @@ mod tests {
         postcard::to_stdvec,
         postcard::from_bytes
     );
-    serde_test!(
-        serialization_bincode,
-        bincode::serialize,
-        bincode::deserialize
-    );
 }


### PR DESCRIPTION
`bincode` is unmaintained. See https://crates.io/crates/bincode/3.0.0