### PR TITLE
Bump `kem` crate dependency to v0.4.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,12 +62,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
-name = "bitflags"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
-
-[[package]]
 name = "block-buffer"
 version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,9 +105,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.3"
+version = "0.10.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3585020fc6766ef7ff5c58d69819dbca16a19008ae347bb5d3e4e145c495eb38"
+checksum = "f895fb33c1ad22da4bc79d37c0bddff8aee2ba4575705345eb73b8ffbc386074"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -290,10 +284,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
+checksum = "29c52310bbf9ce8ad2f05bf8a9b0aa3585532884c31b4f191badfe7d7c7ed127"
 dependencies = [
+ "getrandom",
  "hybrid-array",
  "rand_core",
 ]
@@ -340,6 +335,7 @@ name = "dhkem"
 version = "0.0.1-alpha"
 dependencies = [
  "elliptic-curve",
+ "getrandom",
  "hex-literal",
  "hkdf",
  "k256",
@@ -347,7 +343,6 @@ dependencies = [
  "p256",
  "p384",
  "p521",
- "rand",
  "rand_core",
  "sha2",
  "x25519-dalek",
@@ -430,11 +425,11 @@ dependencies = [
  "aes",
  "chacha20",
  "criterion",
+ "getrandom",
  "hex",
  "hybrid-array",
  "openssl-sys",
  "postcard",
- "rand",
  "rand_core",
  "rstest",
  "serde",
@@ -495,14 +490,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+version = "0.3.4"
+source = "git+https://github.com/rust-random/getrandom#f67c70110f706f80d7dd6fa52e38d0920754fe2c"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
- "windows-targets",
+ "r-efi",
+ "rand_core",
+ "wasip2",
 ]
 
 [[package]]
@@ -675,13 +670,12 @@ dependencies = [
 
 [[package]]
 name = "kem"
-version = "0.4.0-pre.2"
+version = "0.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d92f9203b5234ec3bb463e4a743960b04e0ac171af3e50fb66f2874ffab24c"
+checksum = "34c95ae59585a64f6798efa9a162df3d38864a5f6168a6b188eb2359cfaa6743"
 dependencies = [
  "crypto-common",
  "rand_core",
- "zeroize",
 ]
 
 [[package]]
@@ -718,13 +712,13 @@ version = "0.3.0-pre.2"
 dependencies = [
  "const-oid",
  "criterion",
+ "getrandom",
  "hex",
  "hex-literal",
  "hybrid-array",
  "kem",
  "num-rational",
  "pkcs8",
- "rand",
  "rand_core",
  "serde",
  "serde_json",
@@ -957,21 +951,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.10.0-rc.1"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7d245ced4538f0406b1579d3d4a6515a2ff1bdf20733492e2e4fc90a648769"
-dependencies = [
- "chacha20",
- "getrandom",
- "rand_core",
-]
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-2"
+version = "0.10.0-rc-3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a23e4e8b77312a823b6b5613edbac78397e2f34320bc7ac4277013ec4478e"
+checksum = "f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05"
 
 [[package]]
 name = "rayon"
@@ -1404,12 +1393,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -1572,13 +1561,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "x-wing"
@@ -1588,7 +1574,6 @@ dependencies = [
  "hex",
  "kem",
  "ml-kem",
- "rand",
  "rand_core",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ ml-kem = { path = "./ml-kem" }
 
 elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
 ff = { git = "https://github.com/tarcieri/ff", branch = "rand_core/v0.10.0-rc-2" }
+getrandom = { git = "https://github.com/rust-random/getrandom" }
 group = { git = "https://github.com/tarcieri/group", branch = "rand_core/v0.10.0-rc-2" }
 p256 = { git = "https://github.com/RustCrypto/elliptic-curves " }
 primefield = { git = "https://github.com/RustCrypto/elliptic-curves " }

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["crypto", "ecdh", "ecc"]
 readme = "README.md"
 
 [dependencies]
-kem = "=0.4.0-pre.2"
+kem = "0.4.0-rc.0"
 rand_core = "0.10.0-rc-2"
 
 # optional dependencies
@@ -27,14 +27,16 @@ x25519 = { version = "=3.0.0-pre.1", package = "x25519-dalek", optional = true, 
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
+getrandom = { version = "0.3.4", features = ["sys_rng"] }
 hex-literal = "1"
 hkdf = "0.13.0-rc.3"
-rand = "0.10.0-rc.1"
 sha2 = "0.11.0-rc.3"
 
 [features]
 default = ["zeroize"]
+
 ecdh = ["dep:elliptic-curve", "elliptic-curve/ecdh"]
+getrandom = ["kem/getrandom"]
 k256 = ["dep:k256", "ecdh"]
 p256 = ["dep:p256", "ecdh"]
 p384 = ["dep:p384", "ecdh"]

--- a/dhkem/src/ecdh_kem.rs
+++ b/dhkem/src/ecdh_kem.rs
@@ -21,7 +21,7 @@ where
 {
     type Error = Infallible;
 
-    fn encapsulate<R: TryCryptoRng + ?Sized>(
+    fn encapsulate_with_rng<R: TryCryptoRng + ?Sized>(
         &self,
         rng: &mut R,
     ) -> Result<(PublicKey<C>, SharedSecret<C>), Self::Error> {

--- a/dhkem/src/x25519_kem.rs
+++ b/dhkem/src/x25519_kem.rs
@@ -12,7 +12,7 @@ pub struct X25519Kem;
 impl Encapsulate<PublicKey, SharedSecret> for DhEncapsulator<PublicKey> {
     type Error = Infallible;
 
-    fn encapsulate<R: TryCryptoRng + ?Sized>(
+    fn encapsulate_with_rng<R: TryCryptoRng + ?Sized>(
         &self,
         rng: &mut R,
     ) -> Result<(PublicKey, SharedSecret), Self::Error> {

--- a/dhkem/tests/hpke_p256_test.rs
+++ b/dhkem/tests/hpke_p256_test.rs
@@ -81,7 +81,7 @@ fn test_dhkem_p256_hkdf_sha256() {
     assert_eq!(pkr.to_encoded_point(false).as_bytes(), &pkr_hex);
 
     let (pke, ss1) = pkr
-        .encapsulate(&mut ConstantRng(&hex!(
+        .encapsulate_with_rng(&mut ConstantRng(&hex!(
             "4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb"
         )))
         .expect("never fails");

--- a/dhkem/tests/tests.rs
+++ b/dhkem/tests/tests.rs
@@ -1,6 +1,7 @@
 use dhkem::DhKem;
+use getrandom::SysRng;
 use kem::{Decapsulate, Encapsulate};
-use rand::rng;
+use rand_core::TryRngCore;
 
 trait SecretBytes {
     fn as_slice(&self) -> &[u8];
@@ -30,9 +31,9 @@ fn test_kem<K: DhKem>()
 where
     <K as DhKem>::SharedSecret: SecretBytes,
 {
-    let mut rng = rng();
+    let mut rng = SysRng.unwrap_err();
     let (sk, pk) = K::random_keypair(&mut rng);
-    let (ek, ss1) = pk.encapsulate(&mut rng).expect("never fails");
+    let (ek, ss1) = pk.encapsulate_with_rng(&mut rng).expect("never fails");
     let ss2 = sk.decapsulate(&ek).expect("never fails");
 
     assert_eq!(ss1.as_slice(), ss2.as_slice());

--- a/frodo-kem/Cargo.toml
+++ b/frodo-kem/Cargo.toml
@@ -58,7 +58,7 @@ serde = ["dep:hex", "dep:serde"]
 aes = { version = "0.9.0-rc.2", optional = true }
 hex = { version = "0.4", optional = true }
 openssl-sys = { version = "0.9.104", optional = true }
-rand_core = { version = "0.10.0-rc-2", features = [] }
+rand_core = { version = "0.10.0-rc-3", features = [] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serdect = "0.4"
 subtle = "2.6"
@@ -80,10 +80,10 @@ zeroize = "1"
 [dev-dependencies]
 aes = "0.9.0-rc.2"
 criterion = "0.7"
+getrandom = { version = "0.3.4", features = ["sys_rng"] }
 hex = "0.4"
 hybrid-array = "0.4"
-rand = "0.10.0-rc.1"
-chacha20 = "0.10.0-rc.3"
+chacha20 = { version = "0.10.0-rc.6", features = ["rng"] }
 rstest = "0.26"
 postcard = { version = "1.0", features = ["use-std"] }
 serde_bare = "0.5"

--- a/frodo-kem/src/lib.rs
+++ b/frodo-kem/src/lib.rs
@@ -6,9 +6,10 @@
 //!
 //! ```
 //! use frodo_kem::Algorithm;
-//! use rand::{rngs::OsRng, TryRngCore};
+//! use getrandom::SysRng;
+//! use rand_core::TryRngCore;
 //!
-//! let mut rng = OsRng.unwrap_err();
+//! let mut rng = SysRng.unwrap_err();
 //! let alg = Algorithm::FrodoKem640Shake;
 //! let (ek, dk) = alg.generate_keypair(&mut rng);
 //! let (ct, enc_ss) = alg.encapsulate_with_rng(&ek, &mut rng).unwrap();
@@ -28,9 +29,10 @@
 //!
 //! ```
 //! use frodo_kem::Algorithm;
-//! use rand::{rngs::OsRng, RngCore, TryRngCore};
+//! use getrandom::SysRng;
+//! use rand_core::{RngCore, TryRngCore};
 //!
-//! let mut rng = OsRng.unwrap_err();
+//! let mut rng = SysRng.unwrap_err();
 //! let alg = Algorithm::FrodoKem1344Shake;
 //! let params = alg.params();
 //! let (ek, dk) = alg.generate_keypair(&mut rng);

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -19,14 +19,15 @@ exclude = ["tests/key-gen.rs", "tests/key-gen.json", "tests/encap-decap.rs", "te
 alloc = ["pkcs8?/alloc"]
 
 deterministic = [] # Expose deterministic encapsulation functions
+getrandom = ["kem/getrandom"]
 pem = ["pkcs8/pem"]
 pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 zeroize = ["dep:zeroize"]
 
 [dependencies]
-kem = "=0.4.0-pre.2"
+kem = "0.4.0-rc.0"
 hybrid-array = { version = "0.4.4", features = ["extra-sizes", "subtle"] }
-rand_core = "0.10.0-rc-2"
+rand_core = "0.10.0-rc-3"
 sha3 = { version = "0.11.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
 
@@ -37,10 +38,10 @@ zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
+getrandom = { version = "0.3.4", features = ["sys_rng"] }
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "1"
 num-rational = { version = "0.4.2", default-features = false, features = ["num-bigint"] }
-rand = "0.10.0-rc.1"
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.125"
 

--- a/ml-kem/benches/mlkem.rs
+++ b/ml-kem/benches/mlkem.rs
@@ -1,29 +1,31 @@
-use ::kem::{Decapsulate, Encapsulate};
+use ::kem::{Decapsulate, Encapsulate, Generate};
 use criterion::{Criterion, criterion_group, criterion_main};
+use getrandom::SysRng;
 use ml_kem::*;
+use rand_core::TryRngCore;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let mut rng = rand::rng();
+    let mut rng = SysRng.unwrap_err();
 
     // Key generation
     c.bench_function("keygen", |b| {
         b.iter(|| {
-            let (dk, ek) = <MlKem768 as KemCore>::generate(&mut rng);
+            let dk = ml_kem_768::DecapsulationKey::from_rng(&mut rng);
             let _dk_bytes = dk.as_bytes();
-            let _ek_bytes = ek.as_bytes();
+            let _ek_bytes = dk.encapsulator().as_bytes();
         })
     });
 
-    let (dk, ek) = MlKem768::generate(&mut rng);
+    let dk = ml_kem_768::DecapsulationKey::from_rng(&mut rng);
     let dk_bytes = dk.as_bytes();
-    let ek_bytes = ek.as_bytes();
+    let ek_bytes = dk.encapsulator().as_bytes();
 
-    let ek = <MlKem768 as KemCore>::EncapsulationKey::from_bytes(&ek_bytes);
+    let ek = ml_kem_768::EncapsulationKey::from_bytes(&ek_bytes);
     // Encapsulation
     c.bench_function("encapsulate", |b| {
-        b.iter(|| ek.encapsulate(&mut rng).unwrap())
+        b.iter(|| ek.encapsulate_with_rng(&mut rng).unwrap())
     });
-    let (ct, _ss) = ek.encapsulate(&mut rng).unwrap();
+    let (ct, _ss) = ek.encapsulate_with_rng(&mut rng).unwrap();
 
     // Decapsulation
     let dk = <MlKem768 as KemCore>::DecapsulationKey::from_bytes(&dk_bytes);
@@ -36,8 +38,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     // Round trip
     c.bench_function("round_trip", |b| {
         b.iter(|| {
-            let (dk, ek) = <MlKem768 as KemCore>::generate(&mut rng);
-            let (ct, _sk) = ek.encapsulate(&mut rng).unwrap();
+            let dk = ml_kem_768::DecapsulationKey::from_rng(&mut rng);
+            let ek = dk.encapsulator();
+            let (ct, _sk) = ek.encapsulate_with_rng(&mut rng).unwrap();
             dk.decapsulate(&ct).unwrap();
         })
     });

--- a/ml-kem/src/crypto.rs
+++ b/ml-kem/src/crypto.rs
@@ -1,20 +1,14 @@
 #![allow(dead_code)]
 
-use hybrid_array::{Array, ArraySize};
-use rand_core::CryptoRng;
 use sha3::{
     Digest, Sha3_256, Sha3_512, Shake128, Shake256,
     digest::{ExtendableOutput, Update, XofReader},
 };
 
-use crate::param::{CbdSamplingSize, EncodedPolynomial};
-use crate::util::B32;
-
-pub fn rand<L: ArraySize, R: CryptoRng + ?Sized>(rng: &mut R) -> Array<u8, L> {
-    let mut val = Array::default();
-    rng.fill_bytes(&mut val);
-    val
-}
+use crate::{
+    param::{CbdSamplingSize, EncodedPolynomial},
+    util::B32,
+};
 
 pub fn G(inputs: &[impl AsRef<[u8]>]) -> (B32, B32) {
     let mut h = Sha3_512::new();

--- a/ml-kem/src/encode.rs
+++ b/ml-kem/src/encode.rs
@@ -144,12 +144,11 @@ where
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
-    use core::fmt::Debug;
-    use core::ops::Rem;
+    use core::{fmt::Debug, ops::Rem};
     use hybrid_array::typenum::{
         U1, U2, U3, U4, U5, U6, U8, U10, U11, U12, marker_traits::Zero, operator_aliases::Mod,
     };
-    use rand::Rng;
+    use rand_core::{RngCore, TryRngCore};
 
     use crate::param::EncodedPolynomialVector;
 
@@ -184,9 +183,8 @@ pub(crate) mod test {
         assert_eq!(&actual_decoded, decoded);
 
         // Test random decode/encode and encode/decode round trips
-        let mut rng = rand::rng();
-        let mut decoded: Array<Integer, U256> = Array::default();
-        rng.fill(decoded.as_mut_slice());
+        let mut rng = getrandom::SysRng.unwrap_err();
+        let decoded = Array::<Integer, U256>::from_fn(|_| (rng.next_u32() & 0xFFFF) as Integer);
         let m = match D::USIZE {
             12 => FieldElement::Q,
             d => (1 as Integer) << d,

--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -13,28 +13,29 @@
 
 //! # Usage
 //!
-//! This crate implements the Module-Latice-based Key Encapsulation Method (ML-KEM) algorithm
-//! being standardized by NIST in FIPS 203.  ML-KEM is a KEM in the sense that it creates an
+//! This crate implements the Module-Lattice-based Key Encapsulation Method (ML-KEM) algorithm
+//! being standardized by NIST in FIPS 203.  ML-KEM is a KEM in the sense that it creates a
 //! (decapsulation key, encapsulation key) pair, such that anyone can use the encapsulation key to
 //! establish a shared key with the holder of the decapsulation key.  ML-KEM is the first KEM
 //! algorithm standardized by NIST that is designed to be resistant to attacks using quantum
 //! computers.
 //!
-//! ```
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
+//! // NOTE: requires the `getrandom` feature is enabled
+//!
 //! use ml_kem::{
 //!     ml_kem_768::DecapsulationKey,
-//!     kem::{Decapsulate, Encapsulate, KeyInit}
+//!     kem::{Decapsulate, Encapsulate, Generate, KeyInit}
 //! };
 //!
 //! // Generate a decapsulation/encapsulation keypair
-//! let mut rng = rand::rng();
-//! let seed = DecapsulationKey::generate_key_with_rng(&mut rng);
-//! let dk = DecapsulationKey::new(&seed);
+//! let dk = DecapsulationKey::generate();
 //! let ek = dk.encapsulator();
 //!
 //! // Encapsulate a shared key to the holder of the decapsulation key, receive the shared
 //! // secret `k_send` and the encapsulated form `ct`.
-//! let (ct, k_send) = ek.encapsulate(&mut rng).unwrap();
+//! let (ct, k_send) = ek.encapsulate().unwrap();
 //!
 //! // Decapsulate the shared key and verify that it was faithfully received.
 //! let k_recv = dk.decapsulate(&ct).unwrap();
@@ -198,16 +199,17 @@ pub type MlKem1024 = kem::Kem<MlKem1024Params>;
 mod test {
     use super::*;
     use ::kem::{Decapsulate, Encapsulate};
+    use rand_core::TryRngCore;
 
     fn round_trip_test<K>()
     where
         K: KemCore,
     {
-        let mut rng = rand::rng();
+        let mut rng = getrandom::SysRng.unwrap_err();
 
         let (dk, ek) = K::generate(&mut rng);
 
-        let (ct, k_send) = ek.encapsulate(&mut rng).unwrap();
+        let (ct, k_send) = ek.encapsulate_with_rng(&mut rng).unwrap();
         let k_recv = dk.decapsulate(&ct).unwrap();
         assert_eq!(k_send, k_recv);
     }

--- a/ml-kem/src/pke.rs
+++ b/ml-kem/src/pke.rs
@@ -168,15 +168,17 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::crypto::rand;
     use crate::{MlKem512Params, MlKem768Params, MlKem1024Params};
+    use ::kem::Generate;
+    use getrandom::SysRng;
+    use rand_core::TryRngCore;
 
     fn round_trip_test<P>()
     where
         P: PkeParams,
     {
-        let mut rng = rand::rng();
-        let d: B32 = rand(&mut rng);
+        let mut rng = SysRng.unwrap_err();
+        let d = B32::from_rng(&mut rng);
         let original = B32::default();
         let randomness = B32::default();
 
@@ -197,8 +199,8 @@ mod test {
     where
         P: PkeParams,
     {
-        let mut rng = rand::rng();
-        let d: B32 = rand(&mut rng);
+        let mut rng = SysRng.unwrap_err();
+        let d = B32::from_rng(&mut rng);
         let (dk_original, ek_original) = DecryptionKey::<P>::generate(&d);
 
         let dk_encoded = dk_original.as_bytes();

--- a/ml-kem/tests/pkcs8.rs
+++ b/ml-kem/tests/pkcs8.rs
@@ -11,7 +11,7 @@ use pkcs8::{
         asn1::{ContextSpecific, OctetStringRef},
     },
 };
-use rand_core::CryptoRng;
+use rand_core::{CryptoRng, TryRngCore};
 
 /// ML-KEM seed serialized as ASN.1.
 type SeedString<'a> = ContextSpecific<&'a OctetStringRef>;
@@ -22,7 +22,7 @@ where
     K::EncapsulationKey: EncodePublicKey + DecodePublicKey,
     K::DecapsulationKey: EncodePrivateKey + DecodePrivateKey + From<Seed> + PartialEq,
 {
-    let mut rng = rand::rng();
+    let mut rng = getrandom::SysRng.unwrap_err();
     let (decaps_key, encaps_key) = K::generate(&mut rng);
 
     // TEST: (de)serialize encapsulation key into DER document

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -13,26 +13,25 @@ keywords = ["crypto", "x-wing", "xwing", "kem", "post-quantum"]
 exclude = ["src/test-vectors.json"]
 
 [features]
-getrandom = ["dep:getrandom"]
+getrandom = ["kem/getrandom"]
 zeroize = ["dep:zeroize", "ml-kem/zeroize", "x25519-dalek/zeroize"]
 
 [dependencies]
-kem = "=0.4.0-pre.2"
+kem = "0.4.0-rc.0"
 ml-kem = { version = "=0.3.0-pre.2", default-features = false, features = ["deterministic"] }
-rand_core = { version = "0.10.0-rc-2", default-features = false }
+rand_core = { version = "0.10.0-rc-3", default-features = false }
 sha3 = { version = "0.11.0-rc.3", default-features = false }
 x25519-dalek = { version = "=3.0.0-pre.1", default-features = false, features = ["static_secrets"] }
 
 # optional dependencies
-getrandom = { version = "0.3", optional = true }
 zeroize = { version = "1.8.1", optional = true, default-features = true, features = ["zeroize_derive"] }
 
 [dev-dependencies]
-rand_core = { version = "0.10.0-rc-2" }
+getrandom = { version = "0.3.4", features = ["sys_rng"] }
 hex = { version = "0.4", features = ["serde"] }
+rand_core = "0.10.0-rc-3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rand = "0.10.0-rc.1"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This primarily includes changes to key generation, notably leveraging the `crypto_common::Generate` trait and changing
`Encapsulate::encapsulate` to `Encapsulate::encapsulate_with_rng`.

See RustCrypto/traits#2140 and RustCrypto/traits#2141

It also adds a `getrandom` feature to every crate with `kem` crate support.