### PR TITLE
Use released dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.1"
+version = "5.0.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9200d1d13637f15a6acb71e758f64624048d85b31a5fdbfd8eca1e2687d0b7"
+checksum = "92419e1cdc506051ffd30713ad09d0ec6a24bba9197e12989de389e35b19c77a"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -369,17 +369,18 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.16"
-source = "git+https://github.com/RustCrypto/traits#bd85081709e127b9fa9f885d38252a649f85b581"
+version = "0.14.0-rc.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ecd2903524729de5d0cba7589121744513feadd56d71980cb480c48caceb11"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest",
- "ff",
- "group",
  "hkdf",
  "hybrid-array",
  "rand_core",
+ "rustcrypto-ff",
+ "rustcrypto-group",
  "sec1",
  "subtle",
  "zeroize",
@@ -402,15 +403,6 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "ff"
-version = "0.14.0-pre.0"
-source = "git+https://github.com/tarcieri/ff?branch=rand_core%2Fv0.10.0-rc-2#470e52fa35f7f6cb59f1f005003a14ac50b50cfd"
-dependencies = [
- "rand_core",
- "subtle",
-]
 
 [[package]]
 name = "fiat-crypto"
@@ -505,16 +497,6 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "group"
-version = "0.14.0-pre.0"
-source = "git+https://github.com/tarcieri/group?branch=rand_core%2Fv0.10.0-rc-2#50640b46d5f7eff37aee24d76e991c18444f372e"
-dependencies = [
- "ff",
- "rand_core",
- "subtle",
-]
 
 [[package]]
 name = "half"
@@ -651,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c566022f1abac5de18bdbd126ff463783cf41da8adfb6523ae3f4e46fc90d4"
+checksum = "1527df2d1775d552a836d43dd5eeb5a44ea36429d0752a637a86b3584f107789"
 dependencies = [
  "cfg-if",
  "elliptic-curve",
@@ -792,8 +774,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.0"
-source = "git+https://github.com/RustCrypto/elliptic-curves#c145e37a3cdd16e0903295b2b91e48fdbda11943"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdbe8d6ac92e515ca2179ac331c1e4def09db2217d394683e73dace705c2f0c5"
 dependencies = [
  "elliptic-curve",
  "primefield",
@@ -802,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ae3cc685c1f06b8df2cabb5101eef0116c4a36a413ee7d3403cfc0f0fc7323"
+checksum = "29c729847b7cf17b9c96f9e6504400f64ae90cb1cdf23610cc1a51f18538ff95"
 dependencies = [
  "elliptic-curve",
  "fiat-crypto",
@@ -814,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c973d55b113ae8afe9565bcdecd6ba2484baa7eadca3e64874bfa908dc8d8b"
+checksum = "75296e7cb5d53c8a5083ff26b5707177962cd5851af961a56316e863f1ea757c"
 dependencies = [
  "base16ct",
  "elliptic-curve",
@@ -904,21 +887,22 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.0"
-source = "git+https://github.com/RustCrypto/elliptic-curves#c145e37a3cdd16e0903295b2b91e48fdbda11943"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c3ad342f52c70a953d95acb09a55450fdc07c2214283b81536c3f83f714568e"
 dependencies = [
  "crypto-bigint",
- "ff",
  "rand_core",
+ "rustcrypto-ff",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36714e8f5443e0cc1497f71972788dd95f75bf7253a4393c9f33f3ff9f556cc9"
+checksum = "f5e84a5f07d7a7c85f299e17753a98d8a09f10799894a637c9ce08d834b6ca02"
 dependencies = [
  "elliptic-curve",
 ]
@@ -1053,6 +1037,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustcrypto-ff"
+version = "0.14.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9cd37111549306f79b09aa2618e15b1e8241b7178c286821e3dd71579db4db"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "rustcrypto-group"
+version = "0.14.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e394cd734b5f97dfc3484fa42aad7acd912961c2bcd96c99aa05b3d6cab7cafd"
+dependencies = [
+ "rand_core",
+ "rustcrypto-ff",
+ "subtle",
 ]
 
 [[package]]
@@ -1584,8 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "3.0.0-pre.1"
-source = "git+https://github.com/dalek-cryptography/curve25519-dalek?branch=rand_core%2Fv0.10-rc#a5872540830ef9d51bc2ef0ec53d2268895802a3"
+version = "3.0.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8367a41efe370c38fa4af81968298cdd695311791e4797118a1621f04ed75859"
 dependencies = [
  "curve25519-dalek",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,4 @@ debug = true
 [patch.crates-io]
 ml-kem = { path = "./ml-kem" }
 
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
-ff = { git = "https://github.com/tarcieri/ff", branch = "rand_core/v0.10.0-rc-2" }
 getrandom = { git = "https://github.com/rust-random/getrandom" }
-group = { git = "https://github.com/tarcieri/group", branch = "rand_core/v0.10.0-rc-2" }
-p256 = { git = "https://github.com/RustCrypto/elliptic-curves " }
-primefield = { git = "https://github.com/RustCrypto/elliptic-curves " }
-x25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek", branch = "rand_core/v0.10-rc" }

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -19,11 +19,11 @@ rand_core = "0.10.0-rc-2"
 
 # optional dependencies
 elliptic-curve = { version = "0.14.0-rc.16", optional = true, default-features = false }
-k256 = { version = "0.14.0-rc.0", optional = true, default-features = false, features = ["arithmetic"] }
-p256 = { version = "0.14.0-rc.0", optional = true, default-features = false, features = ["arithmetic"] }
-p384 = { version = "0.14.0-rc.0", optional = true, default-features = false, features = ["arithmetic"] }
-p521 = { version = "0.14.0-rc.0", optional = true, default-features = false, features = ["arithmetic"] }
-x25519 = { version = "=3.0.0-pre.1", package = "x25519-dalek", optional = true, default-features = false }
+k256 = { version = "0.14.0-rc.1", optional = true, default-features = false, features = ["arithmetic"] }
+p256 = { version = "0.14.0-rc.1", optional = true, default-features = false, features = ["arithmetic"] }
+p384 = { version = "0.14.0-rc.1", optional = true, default-features = false, features = ["arithmetic"] }
+p521 = { version = "0.14.0-rc.1", optional = true, default-features = false, features = ["arithmetic"] }
+x25519 = { version = "=3.0.0-pre.3", package = "x25519-dalek", optional = true, default-features = false }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/dhkem/src/ecdh_kem.rs
+++ b/dhkem/src/ecdh_kem.rs
@@ -26,7 +26,8 @@ where
         rng: &mut R,
     ) -> Result<(PublicKey<C>, SharedSecret<C>), Self::Error> {
         // ECDH encapsulation involves creating a new ephemeral key pair and then doing DH
-        let sk = EphemeralSecret::random(&mut rng.unwrap_mut());
+        // TODO(tarcieri): propagate RNG errors
+        let sk = EphemeralSecret::try_from_rng(rng).expect("RNG failure");
         let pk = sk.public_key();
         let ss = sk.diffie_hellman(&self.0);
 
@@ -64,7 +65,8 @@ where
     fn random_keypair<R: CryptoRng + ?Sized>(
         rng: &mut R,
     ) -> (Self::DecapsulatingKey, Self::EncapsulatingKey) {
-        let sk = EphemeralSecret::random(rng);
+        // TODO(tarcieri): propagate RNG errors
+        let sk = EphemeralSecret::try_from_rng(rng).expect("RNG failure");
         let pk = PublicKey::from(&sk);
 
         (DhDecapsulator(sk), DhEncapsulator(pk))

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -21,7 +21,7 @@ kem = "0.4.0-rc.0"
 ml-kem = { version = "=0.3.0-pre.2", default-features = false, features = ["deterministic"] }
 rand_core = { version = "0.10.0-rc-3", default-features = false }
 sha3 = { version = "0.11.0-rc.3", default-features = false }
-x25519-dalek = { version = "=3.0.0-pre.1", default-features = false, features = ["static_secrets"] }
+x25519-dalek = { version = "=3.0.0-pre.3", default-features = false, features = ["static_secrets"] }
 
 # optional dependencies
 zeroize = { version = "1.8.1", optional = true, default-features = true, features = ["zeroize_derive"] }


### PR DESCRIPTION
Removes `patch.crates-io` in favor of using crate releases