### PR TITLE
ml-kem: add `Error` type

### DIFF
--- a/ml-kem/src/error.rs
+++ b/ml-kem/src/error.rs
@@ -1,0 +1,13 @@
+use core::fmt::{self, Display};
+
+/// Error type: deliberately opaque to reduce potential sidechannel leakage.
+#[derive(Clone, Copy, Debug)]
+pub struct Error;
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ML-KEM error")
+    }
+}
+
+impl core::error::Error for Error {}

--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -72,6 +72,8 @@ mod param;
 
 pub mod pkcs8;
 
+/// Error type
+mod error;
 /// Trait definitions
 mod traits;
 
@@ -86,6 +88,7 @@ pub use hybrid_array as array;
 #[cfg(feature = "deterministic")]
 pub use util::B32;
 
+pub use error::Error;
 pub use ml_kem_512::MlKem512Params;
 pub use ml_kem_768::MlKem768Params;
 pub use ml_kem_1024::MlKem1024Params;

--- a/x-wing/src/lib.rs
+++ b/x-wing/src/lib.rs
@@ -29,7 +29,7 @@ pub use kem::{self, Decapsulate, Encapsulate, Generate};
 
 use core::convert::Infallible;
 use ml_kem::{
-    B32, EncodedSizeUser, KemCore, MlKem768, MlKem768Params,
+    B32, EncodedSizeUser, Error, KemCore, MlKem768, MlKem768Params,
     array::{ArrayN, typenum::consts::U32},
 };
 use rand_core::{CryptoRng, TryCryptoRng, TryRngCore};
@@ -75,7 +75,7 @@ pub struct EncapsulationKey {
 }
 
 impl Encapsulate<Ciphertext, SharedSecret> for EncapsulationKey {
-    type Error = Infallible;
+    type Error = Error;
 
     fn encapsulate_with_rng<R: TryCryptoRng + ?Sized>(
         &self,


### PR DESCRIPTION
Uses it to address the TODO in the `Encapsulate::encapsulate_with_rng` impl on `EncapsulationKey` for propagating the RNG error.

It also seems we'll need one to address #172. It might make sense to eventually split this up (e.g. `RngError`, `DecodeError`) but for now this is enough to get started.