### PR TITLE
ml-kem: make `EncodedSizeUser::from_bytes` fallible

### DIFF
--- a/ml-kem/benches/mlkem.rs
+++ b/ml-kem/benches/mlkem.rs
@@ -19,8 +19,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let dk = ml_kem_768::DecapsulationKey::generate_from_rng(&mut rng);
     let dk_bytes = dk.as_bytes();
     let ek_bytes = dk.encapsulator().as_bytes();
+    let ek = ml_kem_768::EncapsulationKey::from_bytes(&ek_bytes).unwrap();
 
-    let ek = ml_kem_768::EncapsulationKey::from_bytes(&ek_bytes);
     // Encapsulation
     c.bench_function("encapsulate", |b| {
         b.iter(|| ek.encapsulate_with_rng(&mut rng).unwrap())
@@ -28,7 +28,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let (ct, _ss) = ek.encapsulate_with_rng(&mut rng).unwrap();
 
     // Decapsulation
-    let dk = <MlKem768 as KemCore>::DecapsulationKey::from_bytes(&dk_bytes);
+    let dk = <MlKem768 as KemCore>::DecapsulationKey::from_bytes(&dk_bytes).unwrap();
+
     c.bench_function("decapsulate", |b| {
         b.iter(|| {
             dk.decapsulate(&ct).unwrap();

--- a/ml-kem/src/pkcs8.rs
+++ b/ml-kem/src/pkcs8.rs
@@ -120,7 +120,7 @@ where
 
     /// Deserialize the encapsulation key from DER format found in `spki.subject_public_key`.
     /// Returns an `EncapsulationKey` containing `ek_{pke}` and `h` in case of success.
-    fn try_from(spki: ::pkcs8::SubjectPublicKeyInfoRef<'_>) -> Result<Self, Self::Error> {
+    fn try_from(spki: ::pkcs8::SubjectPublicKeyInfoRef<'_>) -> Result<Self, spki::Error> {
         if spki.algorithm.oid != P::ALGORITHM_IDENTIFIER.oid {
             return Err(spki::Error::OidUnknown {
                 oid: P::ALGORITHM_IDENTIFIER.oid,
@@ -134,7 +134,7 @@ where
                     Ok(array) => array,
                     Err(_) => return Err(spki::Error::KeyMalformed),
                 };
-                EncryptionKey::from_bytes(&arr)
+                EncryptionKey::from_bytes(&arr).map_err(|_| spki::Error::KeyMalformed)?
             }
             None => return Err(spki::Error::KeyMalformed),
         };

--- a/ml-kem/src/pke.rs
+++ b/ml-kem/src/pke.rs
@@ -5,6 +5,7 @@ use crate::algebra::{NttMatrix, NttVector, Polynomial, PolynomialVector};
 use crate::compress::Compress;
 use crate::crypto::{G, PRF};
 use crate::encode::Encode;
+use crate::error::Error;
 use crate::param::{EncodedCiphertext, EncodedDecryptionKey, EncodedEncryptionKey, PkeParams};
 use crate::util::B32;
 
@@ -155,13 +156,15 @@ where
     }
 
     /// Parse an encryption key from a byte array `(t_hat || rho)`
-    pub fn from_bytes(enc: &EncodedEncryptionKey<P>) -> Self {
+    // TODO(tarcieri): validate decoded keys
+    #[allow(clippy::unnecessary_wraps)]
+    pub fn from_bytes(enc: &EncodedEncryptionKey<P>) -> Result<Self, Error> {
         let (t_hat, rho) = P::split_ek(enc);
         let t_hat = P::decode_u12(t_hat);
-        Self {
+        Ok(Self {
             t_hat,
             rho: rho.clone(),
-        }
+        })
     }
 }
 
@@ -208,7 +211,7 @@ mod test {
         assert_eq!(dk_original, dk_decoded);
 
         let ek_encoded = ek_original.as_bytes();
-        let ek_decoded = EncryptionKey::from_bytes(&ek_encoded);
+        let ek_decoded = EncryptionKey::from_bytes(&ek_encoded).unwrap();
         assert_eq!(ek_original, ek_decoded);
     }
 

--- a/ml-kem/src/traits.rs
+++ b/ml-kem/src/traits.rs
@@ -1,6 +1,6 @@
 //! Trait definitions
 
-use crate::{ArraySize, Ciphertext, Seed, SharedKey};
+use crate::{ArraySize, Ciphertext, Error, Seed, SharedKey};
 use core::fmt::Debug;
 use hybrid_array::Array;
 use kem::{Decapsulate, Encapsulate};
@@ -10,12 +10,15 @@ use rand_core::CryptoRng;
 use crate::B32;
 
 /// An object that knows what size it is
-pub trait EncodedSizeUser {
+pub trait EncodedSizeUser: Sized {
     /// The size of an encoded object
     type EncodedSize: ArraySize;
 
     /// Parse an object from its encoded form
-    fn from_bytes(enc: &Encoded<Self>) -> Self;
+    ///
+    /// # Errors
+    /// - If the object failed to decode successfully
+    fn from_bytes(enc: &Encoded<Self>) -> Result<Self, Error>;
 
     /// Serialize an object to its encoded form
     fn as_bytes(&self) -> Encoded<Self>;

--- a/ml-kem/tests/encap-decap.rs
+++ b/ml-kem/tests/encap-decap.rs
@@ -42,7 +42,7 @@ where
 {
     let m = Array::try_from(tc.m.as_slice()).unwrap();
     let ek_bytes = Encoded::<K::EncapsulationKey>::try_from(tc.ek.as_slice()).unwrap();
-    let ek = K::EncapsulationKey::from_bytes(&ek_bytes);
+    let ek = K::EncapsulationKey::from_bytes(&ek_bytes).unwrap();
 
     let (c, k) = ek.encapsulate_deterministic(&m).unwrap();
 
@@ -62,7 +62,7 @@ fn verify_decap_group(tg: &acvp::DecapTestGroup) {
 
 fn verify_decap<K: KemCore>(tc: &acvp::DecapTestCase, dk_slice: &[u8]) {
     let dk_bytes = Encoded::<K::DecapsulationKey>::try_from(dk_slice).unwrap();
-    let dk = K::DecapsulationKey::from_bytes(&dk_bytes);
+    let dk = K::DecapsulationKey::from_bytes(&dk_bytes).unwrap();
 
     let c = Ciphertext::<K>::try_from(tc.c.as_slice()).unwrap();
     let k = dk.decapsulate(&c).unwrap();

--- a/ml-kem/tests/key-gen.rs
+++ b/ml-kem/tests/key-gen.rs
@@ -41,8 +41,8 @@ fn verify<K: KemCore>(tc: &acvp::TestCase) {
     assert_eq!(ek.as_bytes().as_slice(), tc.ek.as_slice());
 
     // Verify correctness via deserialization
-    assert_eq!(dk, K::DecapsulationKey::from_bytes(&dk_bytes));
-    assert_eq!(ek, K::EncapsulationKey::from_bytes(&ek_bytes));
+    assert_eq!(dk, K::DecapsulationKey::from_bytes(&dk_bytes).unwrap());
+    assert_eq!(ek, K::EncapsulationKey::from_bytes(&ek_bytes).unwrap());
 }
 
 mod acvp {

--- a/x-wing/src/lib.rs
+++ b/x-wing/src/lib.rs
@@ -108,16 +108,18 @@ impl EncapsulationKey {
     }
 }
 
-impl From<&[u8; ENCAPSULATION_KEY_SIZE]> for EncapsulationKey {
-    fn from(value: &[u8; ENCAPSULATION_KEY_SIZE]) -> Self {
+impl TryFrom<&[u8; ENCAPSULATION_KEY_SIZE]> for EncapsulationKey {
+    type Error = ml_kem::Error;
+
+    fn try_from(value: &[u8; ENCAPSULATION_KEY_SIZE]) -> Result<Self, ml_kem::Error> {
         let mut pk_m = [0; 1184];
         pk_m.copy_from_slice(&value[0..1184]);
-        let pk_m = MlKem768EncapsulationKey::from_bytes(&pk_m.into());
+        let pk_m = MlKem768EncapsulationKey::from_bytes(&pk_m.into())?;
 
         let mut pk_x = [0; 32];
         pk_x.copy_from_slice(&value[1184..]);
         let pk_x = PublicKey::from(pk_x);
-        EncapsulationKey { pk_m, pk_x }
+        Ok(EncapsulationKey { pk_m, pk_x })
     }
 }
 
@@ -398,7 +400,7 @@ mod tests {
         let pk_bytes = pk.to_bytes();
 
         let sk_b = DecapsulationKey::from(*sk_bytes);
-        let pk_b = EncapsulationKey::from(&pk_bytes);
+        let pk_b = EncapsulationKey::try_from(&pk_bytes).unwrap();
 
         assert!(sk == sk_b);
         assert!(pk == pk_b);


### PR DESCRIPTION
To handle any sorts of decoding errors (e.g. #172) we need to be able to return decoding errors, so this switches the method to return a `Result`.

Note it doesn't actually add the logic to address #172.