### PR TITLE
ml-kem: rename `EncodedSizeUser::as_bytes` => `to_bytes`

### DIFF
--- a/ml-kem/benches/mlkem.rs
+++ b/ml-kem/benches/mlkem.rs
@@ -11,14 +11,14 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("keygen", |b| {
         b.iter(|| {
             let dk = ml_kem_768::DecapsulationKey::generate_from_rng(&mut rng);
-            let _dk_bytes = dk.as_bytes();
-            let _ek_bytes = dk.encapsulator().as_bytes();
+            let _dk_bytes = dk.to_bytes();
+            let _ek_bytes = dk.encapsulator().to_bytes();
         })
     });
 
     let dk = ml_kem_768::DecapsulationKey::generate_from_rng(&mut rng);
-    let dk_bytes = dk.as_bytes();
-    let ek_bytes = dk.encapsulator().as_bytes();
+    let dk_bytes = dk.to_bytes();
+    let ek_bytes = dk.encapsulator().to_bytes();
     let ek = ml_kem_768::EncapsulationKey::from_bytes(&ek_bytes).unwrap();
 
     // Encapsulation

--- a/ml-kem/src/kem.rs
+++ b/ml-kem/src/kem.rs
@@ -81,9 +81,9 @@ where
         Self::from_expanded(expanded)
     }
 
-    fn as_bytes(&self) -> Encoded<Self> {
-        let dk_pke = self.dk_pke.as_bytes();
-        let ek = self.ek.as_bytes();
+    fn to_bytes(&self) -> Encoded<Self> {
+        let dk_pke = self.dk_pke.to_bytes();
+        let ek = self.ek.to_bytes();
         P::concat_dk(dk_pke, ek, self.ek.h.clone(), self.z.clone())
     }
 }
@@ -239,7 +239,7 @@ where
     P: KemParams,
 {
     pub(crate) fn new(ek_pke: EncryptionKey<P>) -> Self {
-        let h = H(ek_pke.as_bytes());
+        let h = H(ek_pke.to_bytes());
         Self { ek_pke, h }
     }
 
@@ -260,8 +260,8 @@ where
         Ok(Self::new(EncryptionKey::from_bytes(enc)?))
     }
 
-    fn as_bytes(&self) -> Encoded<Self> {
-        self.ek_pke.as_bytes()
+    fn to_bytes(&self) -> Encoded<Self> {
+        self.ek_pke.to_bytes()
     }
 }
 
@@ -367,11 +367,11 @@ mod test {
         let dk_original = DecapsulationKey::<P>::generate_from_rng(&mut rng);
         let ek_original = dk_original.encapsulation_key().clone();
 
-        let dk_encoded = dk_original.as_bytes();
+        let dk_encoded = dk_original.to_bytes();
         let dk_decoded = DecapsulationKey::from_bytes(&dk_encoded).unwrap();
         assert_eq!(dk_original, dk_decoded);
 
-        let ek_encoded = ek_original.as_bytes();
+        let ek_encoded = ek_original.to_bytes();
         let ek_decoded = EncapsulationKey::from_bytes(&ek_encoded).unwrap();
         assert_eq!(ek_original, ek_decoded);
     }

--- a/ml-kem/src/pkcs8.rs
+++ b/ml-kem/src/pkcs8.rs
@@ -101,7 +101,7 @@ where
     /// Serialize the given `EncapsulationKey` into DER format.
     /// Returns a `Document` which wraps the DER document in case of success.
     fn to_public_key_der(&self) -> spki::Result<pkcs8::Document> {
-        let public_key = self.as_bytes();
+        let public_key = self.to_bytes();
         let subject_public_key = BitStringRef::new(0, &public_key)?;
 
         ::pkcs8::SubjectPublicKeyInfo {

--- a/ml-kem/src/pke.rs
+++ b/ml-kem/src/pke.rs
@@ -98,7 +98,7 @@ where
     }
 
     /// Represent this decryption key as a byte array `(s_hat)`
-    pub fn as_bytes(&self) -> EncodedDecryptionKey<P> {
+    pub fn to_bytes(&self) -> EncodedDecryptionKey<P> {
         P::encode_u12(&self.s_hat)
     }
 
@@ -150,7 +150,7 @@ where
     }
 
     /// Represent this encryption key as a byte array `(t_hat || rho)`
-    pub fn as_bytes(&self) -> EncodedEncryptionKey<P> {
+    pub fn to_bytes(&self) -> EncodedEncryptionKey<P> {
         let t_hat = P::encode_u12(&self.t_hat);
         P::concat_ek(t_hat, self.rho.clone())
     }
@@ -194,7 +194,7 @@ where
         // #1 is performed by the `EncodedEncryptionKey` type, and the following check vicariously
         // performs #2 by encoding the integer-mod-q array using our implementation of ByteEncode₁₂
         // and comparing the resulting serialization to see if it round-trips.
-        if &ret.as_bytes() == enc {
+        if &ret.to_bytes() == enc {
             Ok(ret)
         } else {
             Err(Error)
@@ -240,11 +240,11 @@ mod test {
         let d = B32::generate_from_rng(&mut rng);
         let (dk_original, ek_original) = DecryptionKey::<P>::generate(&d);
 
-        let dk_encoded = dk_original.as_bytes();
+        let dk_encoded = dk_original.to_bytes();
         let dk_decoded = DecryptionKey::from_bytes(&dk_encoded);
         assert_eq!(dk_original, dk_decoded);
 
-        let ek_encoded = ek_original.as_bytes();
+        let ek_encoded = ek_original.to_bytes();
         let ek_decoded = EncryptionKey::from_bytes(&ek_encoded).unwrap();
         assert_eq!(ek_original, ek_decoded);
     }

--- a/ml-kem/src/traits.rs
+++ b/ml-kem/src/traits.rs
@@ -21,7 +21,7 @@ pub trait EncodedSizeUser: Sized {
     fn from_bytes(enc: &Encoded<Self>) -> Result<Self, Error>;
 
     /// Serialize an object to its encoded form
-    fn as_bytes(&self) -> Encoded<Self>;
+    fn to_bytes(&self) -> Encoded<Self>;
 }
 
 /// A byte array encoding a value the indicated size

--- a/ml-kem/tests/key-gen.rs
+++ b/ml-kem/tests/key-gen.rs
@@ -37,8 +37,8 @@ fn verify<K: KemCore>(tc: &acvp::TestCase) {
     let (dk, ek) = K::from_seed(d.concat(z));
 
     // Verify correctness via serialization
-    assert_eq!(dk.as_bytes().as_slice(), tc.dk.as_slice());
-    assert_eq!(ek.as_bytes().as_slice(), tc.ek.as_slice());
+    assert_eq!(dk.to_bytes().as_slice(), tc.dk.as_slice());
+    assert_eq!(ek.to_bytes().as_slice(), tc.ek.as_slice());
 
     // Verify correctness via deserialization
     assert_eq!(dk, K::DecapsulationKey::from_bytes(&dk_bytes).unwrap());

--- a/ml-kem/tests/pkcs8.rs
+++ b/ml-kem/tests/pkcs8.rs
@@ -37,7 +37,7 @@ where
         // verify that original encapsulation key corresponds to deserialized encapsulation key
         let pub_key = parsed.decode_msg::<SubjectPublicKeyInfoRef>().unwrap();
         assert_eq!(
-            encaps_key.as_bytes().as_slice(),
+            encaps_key.to_bytes().as_slice(),
             pub_key.subject_public_key.as_bytes().unwrap()
         );
     }

--- a/x-wing/src/lib.rs
+++ b/x-wing/src/lib.rs
@@ -102,7 +102,7 @@ impl EncapsulationKey {
     #[must_use]
     pub fn to_bytes(&self) -> [u8; ENCAPSULATION_KEY_SIZE] {
         let mut buffer = [0u8; ENCAPSULATION_KEY_SIZE];
-        buffer[0..1184].copy_from_slice(&self.pk_m.as_bytes());
+        buffer[0..1184].copy_from_slice(&self.pk_m.to_bytes());
         buffer[1184..1216].copy_from_slice(self.pk_x.as_bytes());
         buffer
     }


### PR DESCRIPTION
...as impl'd on `EncapsulationKey` and `DecapsulationKey`. According to:

https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv

- `as_` is for free borrowed -> borrowed conversions
- `to_` is for expensive borrowed -> owned conversions (used here)

Also, `to_bytes` better pairs with `from_bytes`.