### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,9 +106,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.7"
+version = "0.10.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f659b53b7f4e776e0cb370508f21d62a22349009195b1089de5f9b24afba2f"
+checksum = "31cd65b2ca03198c223cd9a8fa1152c4ec251cd79049f6dc584152ad3fb5ba9d"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.4"
+version = "0.5.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118a99a35f72e30b718e8eb5ea6ba24652d08415260a4a32b838f76aa4e3284a"
+checksum = "b557bad79bc426785757001b5d732f323ae965363983d758295c1a1935496880"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -181,9 +181,9 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cmov"
-version = "0.4.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11ed919bd3bae4af5ab56372b627dfc32622aba6cec36906e8ab46746037c9d"
+checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
 
 [[package]]
 name = "cobs"
@@ -281,9 +281,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.15"
+version = "0.7.0-rc.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9e36ac79ac44866b74e08a0b4925f97b984e3fff17680d2c6fbce8317ab0f6"
+checksum = "f9f9a78b88bb8255ec59a81423aa92ada22f96883f9ae59dcb68613907636ae5"
 dependencies = [
  "ctutils",
  "hybrid-array",
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.10"
+version = "0.2.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fc0003068acd7e9cb6659fd956dc4d671f102a06cc115990b9e7bb5745c25"
+checksum = "7d2bcc93d5cde6659e8649fc412894417ebc14dee54cfc6ee439c683a4a58342"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c67c81499f542d1dd38c6a2a2fe825f4dd4bca5162965dd2eea0c8119873d3c"
+checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
 dependencies = [
  "cmov",
  "subtle",
@@ -390,9 +390,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.21"
+version = "0.14.0-rc.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee4530cd12af66979d89bf0e555c66d04ed1dc58479d7a69d93c98a650fb738"
+checksum = "660a2eb4d46d49d4c0b122a8cad1fa7926b0e3e99913796243a7dc280021eadc"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.4"
+version = "0.14.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbf1872e34241a0a35be724ce5764d90ce8968f26eee3970d0cd5245adc8415"
+checksum = "3cbe701413868feb2738cda41501dbfa923feede3a8609a2c4ddfa2f86638d5d"
 dependencies = [
  "cfg-if",
  "elliptic-curve",
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "kem"
-version = "0.4.0-rc.2"
+version = "0.4.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d025c155be1b6438b1bd2f77497ad73b4946e2433bf838feb274603c89867b"
+checksum = "1e364ee5b2ff87ea53e759732e09cea035602f5c35449088f2d7d05591680272"
 dependencies = [
  "crypto-common",
  "rand_core",
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.4"
+version = "0.14.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb1056e093c065babf1e9b0e28a630bee540cd9f5b905230ddc475175f5e9c8"
+checksum = "a23920bdbd723052dc68186e64d2c8c2a3b2998b42d61df716f67ef771ce358b"
 dependencies = [
  "elliptic-curve",
  "primefield",
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.4"
+version = "0.14.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c56497d041697837a24928437cd1e7e7a7e7705037b0816f94550272e16a8e"
+checksum = "bc8a851b7eed8bfcd741f5dc17c3446eaf8031fa109003fb68f715252cfd4bc9"
 dependencies = [
  "elliptic-curve",
  "fiat-crypto",
@@ -820,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.4"
+version = "0.14.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4383085fff29639c8d8d65e569e3ca58bee723358bd80bb3fb7492d519570989"
+checksum = "5121b1f72223718c1ada46b27c60541e6d2d0f886f7526083aa32c2c23d6686e"
 dependencies = [
  "base16ct",
  "elliptic-curve",
@@ -910,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.4"
+version = "0.14.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1f23afb6185c65efc97605dea2d667f6fef71cb9d3198992c1e9002e349f40"
+checksum = "a90de6476b10bedc43e91337d44440bec88d9c253a1676a046438ba3f5b1d81e"
 dependencies = [
  "crypto-bigint",
  "crypto-common",
@@ -924,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.4"
+version = "0.14.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12459f4bdd430002b812017c3e99f5a27a2c2689f1b140cb82a73c23431b71e0"
+checksum = "e77e56adc743d5601fe3a8534fc7c25a28fbbb7470a4f13700e8fdc6817d3a0a"
 dependencies = [
  "elliptic-curve",
 ]
@@ -1113,9 +1113,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.11"
+version = "0.8.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2568531a8ace88b848310caa98fb2115b151ef924d54aa523e659c21b9d32d71"
+checksum = "5b54617aeb7e34ace1a4b72ba79bb6297e48285dc0cce064dc063ddcbf538996"
 dependencies = [
  "base16ct",
  "ctutils",

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -14,15 +14,15 @@ keywords = ["crypto", "ecdh", "ecc"]
 readme = "README.md"
 
 [dependencies]
-kem = "0.4.0-rc.2"
+kem = "0.4.0-rc.4"
 rand_core = "0.10.0-rc-5"
 
 # optional dependencies
-elliptic-curve = { version = "0.14.0-rc.21", optional = true, default-features = false }
-k256 = { version = "0.14.0-rc.4", optional = true, default-features = false, features = ["arithmetic"] }
-p256 = { version = "0.14.0-rc.4", optional = true, default-features = false, features = ["arithmetic"] }
-p384 = { version = "0.14.0-rc.4", optional = true, default-features = false, features = ["arithmetic"] }
-p521 = { version = "0.14.0-rc.4", optional = true, default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.23", optional = true, default-features = false }
+k256 = { version = "0.14.0-rc.5", optional = true, default-features = false, features = ["arithmetic"] }
+p256 = { version = "0.14.0-rc.5", optional = true, default-features = false, features = ["arithmetic"] }
+p384 = { version = "0.14.0-rc.5", optional = true, default-features = false, features = ["arithmetic"] }
+p521 = { version = "0.14.0-rc.5", optional = true, default-features = false, features = ["arithmetic"] }
 x25519 = { version = "=3.0.0-pre.4", package = "x25519-dalek", optional = true, default-features = false }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 

--- a/frodo-kem/Cargo.toml
+++ b/frodo-kem/Cargo.toml
@@ -83,7 +83,7 @@ criterion = "0.7"
 getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 hex = "0.4"
 hybrid-array = "0.4"
-chacha20 = { version = "0.10.0-rc.7", features = ["rng"] }
+chacha20 = { version = "0.10.0-rc.8", features = ["rng"] }
 rstest = "0.26"
 postcard = { version = "1.0", features = ["use-std"] }
 serde_bare = "0.5"

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -25,7 +25,7 @@ pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 zeroize = ["dep:zeroize"]
 
 [dependencies]
-kem = "0.4.0-rc.2"
+kem = "0.4.0-rc.4"
 hybrid-array = { version = "0.4.4", features = ["extra-sizes", "subtle"] }
 rand_core = "0.10.0-rc-5"
 sha3 = { version = "0.11.0-rc.3", default-features = false }

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -17,7 +17,7 @@ getrandom = ["kem/getrandom"]
 zeroize = ["dep:zeroize", "ml-kem/zeroize", "x25519-dalek/zeroize"]
 
 [dependencies]
-kem = "0.4.0-rc.2"
+kem = "0.4.0-rc.4"
 ml-kem = { version = "=0.3.0-pre.3", default-features = false, features = ["deterministic"] }
 rand_core = { version = "0.10.0-rc-5", default-features = false }
 sha3 = { version = "0.11.0-rc.3", default-features = false }


### PR DESCRIPTION
Bumps the following dependency requirements:

- `chacha20` v0.10.0-rc.8
- `elliptic-curve` v0.14.0-rc.23
- `kem` v0.4.0-rc.4
- `k256` v0.14.0-rc.5
- `p256` v0.14.0-rc.5
- `p384` v0.14.0-rc.5
- `p521` v0.14.0-rc.5