### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "dhkem"
-version = "0.1.0-pre.0"
+version = "0.1.0-pre.1"
 dependencies = [
  "elliptic-curve",
  "getrandom",
@@ -440,7 +440,7 @@ checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
 
 [[package]]
 name = "frodo-kem"
-version = "0.1.0-pre.0"
+version = "0.1.0-pre.1"
 dependencies = [
  "aes",
  "chacha20",
@@ -682,8 +682,9 @@ dependencies = [
 
 [[package]]
 name = "kem"
-version = "0.4.0-rc.4"
-source = "git+https://github.com/RustCrypto/traits#ff1cdb671d40f025788eaa0130558010a0258227"
+version = "0.3.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4584d6b9e14fe98724e721d49f84e203a52a97535ca35b8521857705a356b0f"
 dependencies = [
  "crypto-common",
  "rand_core",
@@ -712,7 +713,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "ml-kem"
-version = "0.3.0-pre.3"
+version = "0.3.0-pre.4"
 dependencies = [
  "const-oid",
  "criterion",
@@ -1519,7 +1520,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "x-wing"
-version = "0.1.0-pre.3"
+version = "0.1.0-pre.4"
 dependencies = [
  "getrandom",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,3 @@ debug = true
 
 [patch.crates-io]
 ml-kem = { path = "./ml-kem" }
-
-kem = { git = "https://github.com/RustCrypto/traits" }

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of Key Encapsulation Mechanism (KEM) adapters for Elliptic Curve
 Diffie Hellman (ECDH) protocols
 """
-version = "0.1.0-pre.0"
+version = "0.1.0-pre.1"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -14,7 +14,7 @@ keywords = ["crypto", "ecdh", "ecc"]
 readme = "README.md"
 
 [dependencies]
-kem = "0.4.0-rc.4"
+kem = "0.3.0-rc.0"
 rand_core = "0.10.0-rc-5"
 
 # optional dependencies

--- a/frodo-kem/Cargo.toml
+++ b/frodo-kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frodo-kem"
-version = "0.1.0-pre.0"
+version = "0.1.0-pre.1"
 description = "Pure Rust implementation of FrodoKEM and eFrodoKEM"
 authors = ["The RustCrypto Team"]
 documentation = "https://docs.rs/frodo-kem"

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Module-Lattice-Based Key-Encapsulation Mechanism Standard
 (formerly known as Kyber) as described in FIPS 203
 """
-version = "0.3.0-pre.3"
+version = "0.3.0-pre.4"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -26,7 +26,7 @@ zeroize = ["dep:zeroize"]
 
 [dependencies]
 array = { package = "hybrid-array", version = "0.4.4", features = ["extra-sizes", "subtle"] }
-kem = "0.4.0-rc.4"
+kem = "0.3.0-rc.0"
 rand_core = "0.10.0-rc-5"
 sha3 = { version = "0.11.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "x-wing"
 description = "Pure Rust implementation of the X-Wing Key Encapsulation Mechanism (draft 06)"
-version = "0.1.0-pre.3"
+version = "0.1.0-pre.4"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -17,8 +17,8 @@ getrandom = ["kem/getrandom"]
 zeroize = ["dep:zeroize", "ml-kem/zeroize", "x25519-dalek/zeroize"]
 
 [dependencies]
-kem = "0.4.0-rc.4"
-ml-kem = { version = "=0.3.0-pre.3", default-features = false, features = ["deterministic"] }
+kem = "0.3.0-rc.0"
+ml-kem = { version = "=0.3.0-pre.4", default-features = false, features = ["deterministic"] }
 rand_core = { version = "0.10.0-rc-5", default-features = false }
 sha3 = { version = "0.11.0-rc.3", default-features = false }
 x25519-dalek = { version = "=3.0.0-pre.4", default-features = false, features = ["static_secrets"] }


### PR DESCRIPTION
Releases the following:
- `dhkem` v0.1.0-pre.1
- `frodo-kem` v0.1.0-pre.1
- `ml-kem` v0.3.0-pre.4
- `x-wing` v0.1.0-pre.4