### PR TITLE
Add `kem::{TryKeyInit + KeyExport}` impls for encapsulation keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.11"
+version = "0.2.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2bcc93d5cde6659e8649fc412894417ebc14dee54cfc6ee439c683a4a58342"
+checksum = "a6dcdb44f2c3ee25689ca12a4c19e664fd09f97aeae0bc5043b2dbab6389e308"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -355,6 +355,7 @@ dependencies = [
 name = "dhkem"
 version = "0.1.0-pre.0"
 dependencies = [
+ "crypto-common",
  "elliptic-curve",
  "getrandom",
  "hex-literal",
@@ -608,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f471e0a81b2f90ffc0cb2f951ae04da57de8baa46fa99112b062a5173a5088d0"
+checksum = "b41fb3dc24fe72c2e3a4685eed55917c2fb228851257f4a8f2d985da9443c3e5"
 dependencies = [
  "subtle",
  "typenum",
@@ -683,8 +684,7 @@ dependencies = [
 [[package]]
 name = "kem"
 version = "0.4.0-rc.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e364ee5b2ff87ea53e759732e09cea035602f5c35449088f2d7d05591680272"
+source = "git+https://github.com/RustCrypto/traits#4e195b4fc5062a9ccd0080070d2b05202b2b3108"
 dependencies = [
  "crypto-common",
  "rand_core",
@@ -717,6 +717,7 @@ version = "0.3.0-pre.3"
 dependencies = [
  "const-oid",
  "criterion",
+ "crypto-common",
  "getrandom",
  "hex",
  "hex-literal",
@@ -1114,8 +1115,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sec1"
 version = "0.8.0-rc.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b54617aeb7e34ace1a4b72ba79bb6297e48285dc0cce064dc063ddcbf538996"
+source = "git+https://github.com/RustCrypto/formats#eb63b10272698f9055b6197c09076dd69acfdc59"
 dependencies = [
  "base16ct",
  "ctutils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ debug = true
 
 [patch.crates-io]
 ml-kem = { path = "./ml-kem" }
+
+kem = { git = "https://github.com/RustCrypto/traits" }
+sec1 = { git = "https://github.com/RustCrypto/formats" }

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -17,6 +17,9 @@ readme = "README.md"
 kem = "0.4.0-rc.4"
 rand_core = "0.10.0-rc-5"
 
+# TODO(tarcieri): remove this and get these from `kem`
+common = { package = "crypto-common", version = "0.2.0-rc.12" }
+
 # optional dependencies
 elliptic-curve = { version = "0.14.0-rc.23", optional = true, default-features = false }
 k256 = { version = "0.14.0-rc.5", optional = true, default-features = false, features = ["arithmetic"] }

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -31,6 +31,9 @@ rand_core = "0.10.0-rc-5"
 sha3 = { version = "0.11.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
 
+# TODO(tarcieri): remove this and get these from `kem`
+common = { package = "crypto-common", version = "0.2.0-rc.12" }
+
 # optional dependencies
 const-oid = { version = "0.10.1", optional = true, default-features = false, features = ["db"] }
 pkcs8 = { version = "0.11.0-rc.8", optional = true, default-features = false }

--- a/ml-kem/benches/mlkem.rs
+++ b/ml-kem/benches/mlkem.rs
@@ -11,15 +11,15 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("keygen", |b| {
         b.iter(|| {
             let dk = ml_kem_768::DecapsulationKey::generate_from_rng(&mut rng);
-            let _dk_bytes = dk.to_bytes();
-            let _ek_bytes = dk.encapsulator().to_bytes();
+            let _dk_bytes = dk.to_encoded_bytes();
+            let _ek_bytes = dk.encapsulator().to_encoded_bytes();
         })
     });
 
     let dk = ml_kem_768::DecapsulationKey::generate_from_rng(&mut rng);
-    let dk_bytes = dk.to_bytes();
-    let ek_bytes = dk.encapsulator().to_bytes();
-    let ek = ml_kem_768::EncapsulationKey::from_bytes(&ek_bytes).unwrap();
+    let dk_bytes = dk.to_encoded_bytes();
+    let ek_bytes = dk.encapsulator().to_encoded_bytes();
+    let ek = ml_kem_768::EncapsulationKey::from_encoded_bytes(&ek_bytes).unwrap();
 
     // Encapsulation
     c.bench_function("encapsulate", |b| {
@@ -28,7 +28,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let (ct, _ss) = ek.encapsulate_with_rng(&mut rng).unwrap();
 
     // Decapsulation
-    let dk = <MlKem768 as KemCore>::DecapsulationKey::from_bytes(&dk_bytes).unwrap();
+    let dk = <MlKem768 as KemCore>::DecapsulationKey::from_encoded_bytes(&dk_bytes).unwrap();
 
     c.bench_function("decapsulate", |b| {
         b.iter(|| {

--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -26,8 +26,9 @@
 //!
 //! use ml_kem::{
 //!     ml_kem_768::DecapsulationKey,
-//!     kem::{Decapsulate, Encapsulate, Generate, KeyInit}
+//!     kem::{Decapsulate, Encapsulate, Generate}
 //! };
+//! use common::KeyInit; // TODO(tarcieri): fix this!
 //!
 //! // Generate a decapsulation/encapsulation keypair
 //! let dk = DecapsulationKey::generate();
@@ -94,6 +95,9 @@ pub use ml_kem_768::MlKem768Params;
 pub use ml_kem_1024::MlKem1024Params;
 pub use param::{ArraySize, ExpandedDecapsulationKey, ParameterSet};
 pub use traits::*;
+
+// TODO(tarcieri): get rid of this!
+pub use common;
 
 /// ML-KEM seeds are decapsulation (private) keys, which are consistently 64-bytes across all
 /// security levels, and are the preferred serialization for representing such keys.

--- a/ml-kem/src/pkcs8.rs
+++ b/ml-kem/src/pkcs8.rs
@@ -101,7 +101,7 @@ where
     /// Serialize the given `EncapsulationKey` into DER format.
     /// Returns a `Document` which wraps the DER document in case of success.
     fn to_public_key_der(&self) -> spki::Result<pkcs8::Document> {
-        let public_key = self.to_bytes();
+        let public_key = self.to_encoded_bytes();
         let subject_public_key = BitStringRef::new(0, &public_key)?;
 
         ::pkcs8::SubjectPublicKeyInfo {

--- a/ml-kem/src/traits.rs
+++ b/ml-kem/src/traits.rs
@@ -18,10 +18,10 @@ pub trait EncodedSizeUser: Sized {
     ///
     /// # Errors
     /// - If the object failed to decode successfully
-    fn from_bytes(enc: &Encoded<Self>) -> Result<Self, Error>;
+    fn from_encoded_bytes(enc: &Encoded<Self>) -> Result<Self, Error>;
 
     /// Serialize an object to its encoded form
-    fn to_bytes(&self) -> Encoded<Self>;
+    fn to_encoded_bytes(&self) -> Encoded<Self>;
 }
 
 /// A byte array encoding a value the indicated size

--- a/ml-kem/tests/encap-decap.rs
+++ b/ml-kem/tests/encap-decap.rs
@@ -42,7 +42,7 @@ where
 {
     let m = Array::try_from(tc.m.as_slice()).unwrap();
     let ek_bytes = Encoded::<K::EncapsulationKey>::try_from(tc.ek.as_slice()).unwrap();
-    let ek = K::EncapsulationKey::from_bytes(&ek_bytes).unwrap();
+    let ek = K::EncapsulationKey::from_encoded_bytes(&ek_bytes).unwrap();
 
     let (c, k) = ek.encapsulate_deterministic(&m).unwrap();
 
@@ -62,7 +62,7 @@ fn verify_decap_group(tg: &acvp::DecapTestGroup) {
 
 fn verify_decap<K: KemCore>(tc: &acvp::DecapTestCase, dk_slice: &[u8]) {
     let dk_bytes = Encoded::<K::DecapsulationKey>::try_from(dk_slice).unwrap();
-    let dk = K::DecapsulationKey::from_bytes(&dk_bytes).unwrap();
+    let dk = K::DecapsulationKey::from_encoded_bytes(&dk_bytes).unwrap();
 
     let c = Ciphertext::<K>::try_from(tc.c.as_slice()).unwrap();
     let k = dk.decapsulate(&c).unwrap();

--- a/ml-kem/tests/key-gen.rs
+++ b/ml-kem/tests/key-gen.rs
@@ -37,12 +37,18 @@ fn verify<K: KemCore>(tc: &acvp::TestCase) {
     let (dk, ek) = K::from_seed(d.concat(z));
 
     // Verify correctness via serialization
-    assert_eq!(dk.to_bytes().as_slice(), tc.dk.as_slice());
-    assert_eq!(ek.to_bytes().as_slice(), tc.ek.as_slice());
+    assert_eq!(dk.to_encoded_bytes().as_slice(), tc.dk.as_slice());
+    assert_eq!(ek.to_encoded_bytes().as_slice(), tc.ek.as_slice());
 
     // Verify correctness via deserialization
-    assert_eq!(dk, K::DecapsulationKey::from_bytes(&dk_bytes).unwrap());
-    assert_eq!(ek, K::EncapsulationKey::from_bytes(&ek_bytes).unwrap());
+    assert_eq!(
+        dk,
+        K::DecapsulationKey::from_encoded_bytes(&dk_bytes).unwrap()
+    );
+    assert_eq!(
+        ek,
+        K::EncapsulationKey::from_encoded_bytes(&ek_bytes).unwrap()
+    );
 }
 
 mod acvp {

--- a/ml-kem/tests/pkcs8.rs
+++ b/ml-kem/tests/pkcs8.rs
@@ -37,7 +37,7 @@ where
         // verify that original encapsulation key corresponds to deserialized encapsulation key
         let pub_key = parsed.decode_msg::<SubjectPublicKeyInfoRef>().unwrap();
         assert_eq!(
-            encaps_key.to_bytes().as_slice(),
+            encaps_key.to_encoded_bytes().as_slice(),
             pub_key.subject_public_key.as_bytes().unwrap()
         );
     }


### PR DESCRIPTION
Also adds a `KeySizeUser` impl.

This is a companion PR to RustCrypto/traits#2215 which added a bound to the `Encapsulate` trait for `TryKeyInit + KeyExport` from `crypto-common`.

These traits both have a supertrait bound on `KeySizeUser`, which defines an `ArraySize` for a fixed-size key.

The other two provide common traits for fallible decoding and encoding respectively, where the former uses the common `InvalidKey` type also defined in the `crypto-common` crate.

This was one big missing gap for generic KEM use.

Some traits we need aren't being re-exported from `kem` and it doesn't do a re-export of `crypto-common` so this has a few TODOs to follow up on that. We need to get this landed first though.