### PR TITLE
kem: use byte arrays for `EK` and `SS`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "kem"
 version = "0.4.0-rc.4"
-source = "git+https://github.com/RustCrypto/traits#55376359fd1375ebd63825a4c1394d3c3ee3e6de"
+source = "git+https://github.com/RustCrypto/traits#ff1cdb671d40f025788eaa0130558010a0258227"
 dependencies = [
  "crypto-common",
  "rand_core",
@@ -1112,8 +1112,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.12"
-source = "git+https://github.com/RustCrypto/formats#eb63b10272698f9055b6197c09076dd69acfdc59"
+version = "0.8.0-rc.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2400ed44a13193820aa528a19f376c3843141a8ce96ff34b11104cc79763f2"
 dependencies = [
  "base16ct",
  "ctutils",
@@ -1568,20 +1569,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,3 @@ debug = true
 ml-kem = { path = "./ml-kem" }
 
 kem = { git = "https://github.com/RustCrypto/traits" }
-sec1 = { git = "https://github.com/RustCrypto/formats" }

--- a/dhkem/src/x25519_kem.rs
+++ b/dhkem/src/x25519_kem.rs
@@ -1,14 +1,36 @@
-use crate::{DhDecapsulator, DhEncapsulator, DhKem};
+use crate::{DecapsulationKey, DhKem, EncapsulationKey};
 use kem::{
-    Decapsulate, Encapsulate, InvalidKey, Key, KeyExport, KeySizeUser, TryKeyInit, consts::U32,
+    Decapsulate, Decapsulator, Encapsulate, Generate, InvalidKey, KemParams, Key, KeyExport,
+    KeySizeUser, TryKeyInit, common::array::Array, consts::U32,
 };
 use rand_core::{CryptoRng, TryCryptoRng, UnwrapErr};
-use x25519::{PublicKey, ReusableSecret, SharedSecret};
+use x25519::{PublicKey, ReusableSecret};
+
+/// Elliptic Curve Diffie-Hellman Decapsulation Key (i.e. secret decryption key)
+///
+/// Generic around an elliptic curve `C`.
+pub type X25519DecapsulationKey = DecapsulationKey<ReusableSecret, PublicKey>;
+
+/// Elliptic Curve Diffie-Hellman Encapsulation Key (i.e. public encryption key)
+///
+/// Generic around an elliptic curve `C`.
+pub type X25519EncapsulationKey = EncapsulationKey<PublicKey>;
+
+/// X25519 ciphertexts are compressed Montgomery x/u-coordinates.
+type Ciphertext = Array<u8, U32>;
+
+/// X25519 shared secrets are also compressed Montgomery x/u-coordinates.
+type SharedSecret = Array<u8, U32>;
 
 /// X22519 Diffie-Hellman KEM adapter.
 ///
 /// Implements a KEM interface that internally uses X25519 ECDH.
 pub struct X25519Kem;
+
+impl KemParams for EncapsulationKey<PublicKey> {
+    type CiphertextSize = U32;
+    type SharedSecretSize = U32;
+}
 
 /// From [RFC9810 §7.1.1]: `SerializePublicKey` and `DeserializePublicKey`:
 ///
@@ -17,7 +39,7 @@ pub struct X25519Kem;
 /// > these curves already use fixed-length byte strings for public keys.
 ///
 /// [RFC9810 §7.1.1]: https://datatracker.ietf.org/doc/html/rfc9180#name-serializepublickey-and-dese
-impl KeySizeUser for DhEncapsulator<PublicKey> {
+impl KeySizeUser for X25519EncapsulationKey {
     type KeySize = U32;
 }
 
@@ -28,7 +50,7 @@ impl KeySizeUser for DhEncapsulator<PublicKey> {
 /// > these curves already use fixed-length byte strings for public keys.
 ///
 /// [RFC9810 §7.1.1]: https://datatracker.ietf.org/doc/html/rfc9180#name-serializepublickey-and-dese
-impl TryKeyInit for DhEncapsulator<PublicKey> {
+impl TryKeyInit for X25519EncapsulationKey {
     fn new(encapsulation_key: &Key<Self>) -> Result<Self, InvalidKey> {
         Ok(Self(PublicKey::from(encapsulation_key.0)))
     }
@@ -41,50 +63,54 @@ impl TryKeyInit for DhEncapsulator<PublicKey> {
 /// > these curves already use fixed-length byte strings for public keys.
 ///
 /// [RFC9810 §7.1.1]: https://datatracker.ietf.org/doc/html/rfc9180#name-serializepublickey-and-dese
-impl KeyExport for DhEncapsulator<PublicKey> {
+impl KeyExport for X25519EncapsulationKey {
     fn to_bytes(&self) -> Key<Self> {
         self.0.to_bytes().into()
     }
 }
 
-impl Encapsulate<PublicKey, SharedSecret> for DhEncapsulator<PublicKey> {
+impl Encapsulate for X25519EncapsulationKey {
     fn encapsulate_with_rng<R: TryCryptoRng + ?Sized>(
         &self,
         rng: &mut R,
-    ) -> Result<(PublicKey, SharedSecret), R::Error> {
+    ) -> Result<(Ciphertext, SharedSecret), R::Error> {
         // ECDH encapsulation involves creating a new ephemeral key pair and then doing DH
+        // TODO(tarcieri): don't panic! Fallible `ReusableSecret` generation?
         let sk = ReusableSecret::random_from_rng(&mut UnwrapErr(rng));
         let pk = PublicKey::from(&sk);
         let ss = sk.diffie_hellman(&self.0);
-
-        Ok((pk, ss))
+        Ok((pk.to_bytes().into(), ss.to_bytes().into()))
     }
 }
 
-impl Decapsulate<PublicKey, SharedSecret> for DhDecapsulator<ReusableSecret> {
-    type Encapsulator = DhEncapsulator<PublicKey>;
-
-    fn decapsulate(&self, encapsulated_key: &PublicKey) -> SharedSecret {
-        self.0.diffie_hellman(encapsulated_key)
+impl Generate for X25519DecapsulationKey {
+    fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        // TODO(tarcieri): don't panic! Fallible `ReusableSecret` generation?
+        Ok(Self::from(ReusableSecret::random_from_rng(&mut UnwrapErr(
+            rng,
+        ))))
     }
+}
 
-    fn encapsulator(&self) -> DhEncapsulator<PublicKey> {
-        DhEncapsulator(PublicKey::from(&self.0))
+impl Decapsulate for X25519DecapsulationKey {
+    fn decapsulate(&self, encapsulated_key: &Ciphertext) -> SharedSecret {
+        let public_key = PublicKey::from(encapsulated_key.0);
+        self.dk.diffie_hellman(&public_key).to_bytes().into()
     }
 }
 
 impl DhKem for X25519Kem {
-    type DecapsulatingKey = DhDecapsulator<ReusableSecret>;
-    type EncapsulatingKey = DhEncapsulator<PublicKey>;
-    type EncapsulatedKey = PublicKey;
-    type SharedSecret = SharedSecret;
+    type DecapsulatingKey = X25519DecapsulationKey;
+    type EncapsulatingKey = X25519EncapsulationKey;
+    type EncapsulatedKey = Ciphertext;
+    type SharedSecret = x25519::SharedSecret;
 
-    fn random_keypair<R: CryptoRng + ?Sized>(
-        rng: &mut R,
-    ) -> (Self::DecapsulatingKey, Self::EncapsulatingKey) {
-        let sk = ReusableSecret::random_from_rng(rng);
-        let pk = PublicKey::from(&sk);
-
-        (DhDecapsulator(sk), DhEncapsulator(pk))
+    fn random_keypair<R>(rng: &mut R) -> (Self::DecapsulatingKey, Self::EncapsulatingKey)
+    where
+        R: CryptoRng + ?Sized,
+    {
+        let dk = Self::DecapsulatingKey::generate_from_rng(rng);
+        let ek = *dk.encapsulator();
+        (dk, ek)
     }
 }

--- a/dhkem/tests/hpke_p256_test.rs
+++ b/dhkem/tests/hpke_p256_test.rs
@@ -1,11 +1,11 @@
 #![cfg(feature = "p256")]
 
 use core::convert::Infallible;
-use dhkem::{DhKem, NistP256Kem};
-use elliptic_curve::sec1::ToEncodedPoint;
+use dhkem::NistP256DecapsulationKey;
+use elliptic_curve::Generate;
 use hex_literal::hex;
 use hkdf::Hkdf;
-use kem::{Decapsulate, Encapsulate};
+use kem::{Decapsulator, Encapsulate, KeyExport, TryDecapsulate};
 use rand_core::{TryCryptoRng, TryRngCore};
 use sha2::Sha256;
 
@@ -60,43 +60,45 @@ fn labeled_expand(prk: &[u8], label: &[u8], info: &[u8], l: u16) -> Vec<u8> {
     out
 }
 
-fn extract_and_expand(dh: <NistP256Kem as DhKem>::SharedSecret, kem_context: &[u8]) -> Vec<u8> {
-    let eae_prk = labeled_extract(b"", b"eae_prk", dh.raw_secret_bytes());
+fn extract_and_expand(shared_secret: &[u8], kem_context: &[u8]) -> Vec<u8> {
+    let eae_prk = labeled_extract(b"", b"eae_prk", shared_secret);
     labeled_expand(&eae_prk, b"shared_secret", kem_context, 32)
 }
 
 #[test]
 // section A.3.1 https://datatracker.ietf.org/doc/html/rfc9180#appendix-A.3.1
 fn test_dhkem_p256_hkdf_sha256() {
-    let pke_hex = hex!(
+    let example_pke = hex!(
         "04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b32\
-                  5ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4"
+         5ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4"
     );
-    let pkr_hex = hex!(
+    let example_pkr = hex!(
         "04fe8c19ce0905191ebc298a9245792531f26f0cece2460639e8bc39cb7f70\
-                  6a826a779b4cf969b8a0e539c7f62fb3d30ad6aa8f80e30f1d128aafd68a2ce72ea0"
+         6a826a779b4cf969b8a0e539c7f62fb3d30ad6aa8f80e30f1d128aafd68a2ce72ea0"
     );
-    let shared_secret_hex =
+    let example_shared_secret =
         hex!("c0d26aeab536609a572b07695d933b589dcf363ff9d93c93adea537aeabb8cb8");
 
-    let (skr, pkr) = NistP256Kem::random_keypair(&mut ConstantRng(&hex!(
+    let skr = NistP256DecapsulationKey::try_generate_from_rng(&mut ConstantRng(&hex!(
         "f3ce7fdae57e1a310d87f1ebbde6f328be0a99cdbcadf4d6589cf29de4b8ffd2"
-    )));
-    assert_eq!(pkr.to_encoded_point(false).as_bytes(), &pkr_hex);
+    )))
+    .unwrap();
+    let pkr = skr.encapsulator();
+    assert_eq!(&pkr.to_bytes(), &example_pkr);
 
     let (pke, ss1) = pkr
         .encapsulate_with_rng(&mut ConstantRng(&hex!(
             "4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb"
         )))
         .expect("never fails");
-    assert_eq!(pke.to_encoded_point(false).as_bytes(), &pke_hex);
+    assert_eq!(&pke, &example_pke);
 
-    let ss2 = skr.decapsulate(&pke);
+    let ss2 = skr.try_decapsulate(&pke).unwrap();
 
-    assert_eq!(ss1.raw_secret_bytes(), ss2.raw_secret_bytes());
+    assert_eq!(ss1, ss2);
 
-    let kem_context = [pke_hex, pkr_hex].concat();
-    let shared_secret = extract_and_expand(ss1, &kem_context);
+    let kem_context = [example_pke, example_pkr].concat();
+    let shared_secret = extract_and_expand(&ss1, &kem_context);
 
-    assert_eq!(&shared_secret, &shared_secret_hex);
+    assert_eq!(&shared_secret, &example_shared_secret);
 }

--- a/dhkem/tests/tests.rs
+++ b/dhkem/tests/tests.rs
@@ -1,70 +1,44 @@
-use dhkem::DhKem;
 use getrandom::SysRng;
-use kem::{Decapsulate, Encapsulate};
-use rand_core::TryRngCore;
-
-trait SecretBytes {
-    fn as_slice(&self) -> &[u8];
-}
-
-#[cfg(feature = "x25519")]
-impl SecretBytes for x25519::SharedSecret {
-    fn as_slice(&self) -> &[u8] {
-        self.as_bytes().as_slice()
-    }
-}
-
-#[cfg(feature = "ecdh")]
-impl<C> SecretBytes for elliptic_curve::ecdh::SharedSecret<C>
-where
-    C: elliptic_curve::CurveArithmetic,
-{
-    fn as_slice(&self) -> &[u8] {
-        self.raw_secret_bytes().as_slice()
-    }
-}
+use kem::{Decapsulator, Encapsulate, Generate, TryDecapsulate};
 
 // we need this because if the crate is compiled with no features this function never
 // gets used
 #[allow(dead_code)]
-fn test_kem<K: DhKem>()
-where
-    <K as DhKem>::SharedSecret: SecretBytes,
-{
-    let mut rng = SysRng.unwrap_err();
-    let (sk, pk) = K::random_keypair(&mut rng);
-    let (ek, ss1) = pk.encapsulate_with_rng(&mut rng).expect("never fails");
-    let ss2 = sk.decapsulate(&ek);
-
+fn test_kem<DK: Decapsulator + Generate + TryDecapsulate>() {
+    let mut rng = SysRng;
+    let dk = DK::try_generate_from_rng(&mut SysRng).unwrap();
+    let ek = dk.encapsulator();
+    let (ek, ss1) = ek.encapsulate_with_rng(&mut rng).unwrap();
+    let ss2 = dk.try_decapsulate(&ek).unwrap();
     assert_eq!(ss1.as_slice(), ss2.as_slice());
 }
 
 #[cfg(feature = "x25519")]
 #[test]
 fn test_x25519() {
-    test_kem::<dhkem::X25519Kem>();
+    test_kem::<dhkem::X25519DecapsulationKey>();
 }
 
 #[cfg(feature = "k256")]
 #[test]
 fn test_k256() {
-    test_kem::<dhkem::Secp256k1Kem>();
+    test_kem::<dhkem::Secp256k1DecapsulationKey>();
 }
 
 #[cfg(feature = "p256")]
 #[test]
 fn test_p256() {
-    test_kem::<dhkem::NistP256Kem>();
+    test_kem::<dhkem::NistP256DecapsulationKey>();
 }
 
 #[cfg(feature = "p384")]
 #[test]
 fn test_p384() {
-    test_kem::<dhkem::NistP384Kem>();
+    test_kem::<dhkem::NistP384DecapsulationKey>();
 }
 
 #[cfg(feature = "p521")]
 #[test]
 fn test_p521() {
-    test_kem::<dhkem::NistP521Kem>();
+    test_kem::<dhkem::NistP521DecapsulationKey>();
 }

--- a/ml-kem/benches/mlkem.rs
+++ b/ml-kem/benches/mlkem.rs
@@ -1,4 +1,4 @@
-use ::kem::{Decapsulate, Encapsulate, Generate};
+use ::kem::{Decapsulate, Decapsulator, Encapsulate, Generate};
 use criterion::{Criterion, criterion_group, criterion_main};
 use getrandom::SysRng;
 use ml_kem::*;

--- a/ml-kem/src/algebra.rs
+++ b/ml-kem/src/algebra.rs
@@ -425,7 +425,7 @@ impl NttPolynomial {
 }
 
 /// A vector of K NTT-domain polynomials
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug)]
 pub struct NttVector<K: ArraySize>(pub Array<NttPolynomial, K>);
 
 impl<K: ArraySize> NttVector<K> {
@@ -441,6 +441,14 @@ impl<K: ArraySize> NttVector<K> {
 impl<K: ArraySize> ConstantTimeEq for NttVector<K> {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
+    }
+}
+
+impl<K: ArraySize> Eq for NttVector<K> {}
+impl<K: ArraySize> PartialEq for NttVector<K> {
+    fn eq(&self, other: &Self) -> bool {
+        // Impl `PartialEq` in constant-time, in case this value contains a secret
+        self.0.ct_eq(&other.0).into()
     }
 }
 

--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! use ml_kem::{
 //!     ml_kem_768::DecapsulationKey,
-//!     kem::{Decapsulate, Encapsulate, Generate, KeyInit}
+//!     kem::{Decapsulate, Decapsulator, Encapsulate, Generate, KeyInit}
 //! };
 //!
 //! // Generate a decapsulation/encapsulation keypair
@@ -178,6 +178,30 @@ pub mod ml_kem_1024 {
     pub type EncapsulationKey = kem::EncapsulationKey<MlKem1024Params>;
 }
 
+/// An ML-KEM-512 `DecapsulationKey` which provides the ability to generate a new key pair, and
+/// decapsulate an encapsulated shared key.
+pub type DecapsulationKey512 = ml_kem_512::DecapsulationKey;
+
+/// An ML-KEM-512 `EncapsulationKey` provides the ability to encapsulate a shared key so that it
+/// can only be decapsulated by the holder of the corresponding decapsulation key.
+pub type EncapsulationKey512 = ml_kem_512::EncapsulationKey;
+
+/// An ML-KEM-768 `DecapsulationKey` which provides the ability to generate a new key pair, and
+/// decapsulate an encapsulated shared key.
+pub type DecapsulationKey768 = ml_kem_768::DecapsulationKey;
+
+/// An ML-KEM-768 `EncapsulationKey` provides the ability to encapsulate a shared key so that it
+/// can only be decapsulated by the holder of the corresponding decapsulation key.
+pub type EncapsulationKey768 = ml_kem_768::EncapsulationKey;
+
+/// An ML-KEM-1024 `DecapsulationKey` which provides the ability to generate a new key pair, and
+/// decapsulate an encapsulated shared key.
+pub type DecapsulationKey1024 = ml_kem_1024::DecapsulationKey;
+
+/// An ML-KEM-1024 `EncapsulationKey` provides the ability to encapsulate a shared key so that it
+/// can only be decapsulated by the holder of the corresponding decapsulation key.
+pub type EncapsulationKey1024 = ml_kem_1024::EncapsulationKey;
+
 /// A shared key produced by the KEM `K`
 pub type SharedKey<K> = Array<u8, <K as KemCore>::SharedKeySize>;
 
@@ -197,28 +221,26 @@ pub type MlKem768 = kem::Kem<MlKem768Params>;
 pub type MlKem1024 = kem::Kem<MlKem1024Params>;
 
 #[cfg(test)]
+#[cfg(feature = "getrandom")]
 mod test {
     use super::*;
-    use ::kem::{Decapsulate, Encapsulate};
-    use rand_core::TryRngCore;
+    use ::kem::{Decapsulate, Encapsulate, Generate};
 
     fn round_trip_test<K>()
     where
-        K: KemCore,
+        K: Decapsulate + Generate,
     {
-        let mut rng = getrandom::SysRng.unwrap_err();
-
-        let (dk, ek) = K::generate(&mut rng);
-
-        let (ct, k_send) = ek.encapsulate_with_rng(&mut rng).unwrap();
+        let dk = K::generate();
+        let ek = dk.encapsulator();
+        let (ct, k_send) = ek.encapsulate();
         let k_recv = dk.decapsulate(&ct);
         assert_eq!(k_send, k_recv);
     }
 
     #[test]
     fn round_trip() {
-        round_trip_test::<MlKem512>();
-        round_trip_test::<MlKem768>();
-        round_trip_test::<MlKem1024>();
+        round_trip_test::<DecapsulationKey512>();
+        round_trip_test::<DecapsulationKey768>();
+        round_trip_test::<DecapsulationKey1024>();
     }
 }

--- a/ml-kem/src/pke.rs
+++ b/ml-kem/src/pke.rs
@@ -30,12 +30,13 @@ where
     }
 }
 
-// Handwritten to ensure a constant time comparison is performed
+impl<P> Eq for DecryptionKey<P> where P: PkeParams {}
 impl<P> PartialEq for DecryptionKey<P>
 where
     P: PkeParams,
 {
     fn eq(&self, other: &Self) -> bool {
+        // Compare decryption keys in constant-time
         self.ct_eq(other).into()
     }
 }
@@ -110,7 +111,7 @@ where
 
 /// An `EncryptionKey` provides the ability to encrypt a value so that it can only be
 /// decrypted by the holder of the corresponding decapsulation key.
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct EncryptionKey<P>
 where
     P: PkeParams,

--- a/ml-kem/src/traits.rs
+++ b/ml-kem/src/traits.rs
@@ -1,6 +1,6 @@
 //! Trait definitions
 
-use crate::{ArraySize, Ciphertext, Seed, SharedKey};
+use crate::{ArraySize, Seed};
 use array::Array;
 use core::fmt::Debug;
 use kem::{Decapsulate, Encapsulate, InvalidKey};
@@ -51,17 +51,10 @@ pub trait KemCore: Clone {
     type CiphertextSize: ArraySize;
 
     /// A decapsulation key for this KEM
-    type DecapsulationKey: Decapsulate<Ciphertext<Self>, SharedKey<Self>>
-        + EncodedSizeUser
-        + Debug
-        + PartialEq;
+    type DecapsulationKey: Decapsulate + EncodedSizeUser + Debug + PartialEq;
 
     /// An encapsulation key for this KEM
-    type EncapsulationKey: Encapsulate<Ciphertext<Self>, SharedKey<Self>>
-        + EncodedSizeUser
-        + Clone
-        + Debug
-        + PartialEq;
+    type EncapsulationKey: Encapsulate + EncodedSizeUser + Clone + Debug + Eq + PartialEq;
 
     /// Generate a new (decapsulation, encapsulation) key pair.
     fn generate<R: CryptoRng + ?Sized>(

--- a/ml-kem/tests/encap-decap.rs
+++ b/ml-kem/tests/encap-decap.rs
@@ -53,18 +53,18 @@ where
 fn verify_decap_group(tg: &acvp::DecapTestGroup) {
     for tc in tg.tests.iter() {
         match tg.parameter_set {
-            acvp::ParameterSet::MlKem512 => verify_decap::<MlKem512>(tc, &tg.dk),
-            acvp::ParameterSet::MlKem768 => verify_decap::<MlKem768>(tc, &tg.dk),
-            acvp::ParameterSet::MlKem1024 => verify_decap::<MlKem1024>(tc, &tg.dk),
+            acvp::ParameterSet::MlKem512 => verify_decap::<DecapsulationKey512>(tc, &tg.dk),
+            acvp::ParameterSet::MlKem768 => verify_decap::<DecapsulationKey768>(tc, &tg.dk),
+            acvp::ParameterSet::MlKem1024 => verify_decap::<DecapsulationKey1024>(tc, &tg.dk),
         }
     }
 }
 
-fn verify_decap<K: KemCore>(tc: &acvp::DecapTestCase, dk_slice: &[u8]) {
-    let dk_bytes = Encoded::<K::DecapsulationKey>::try_from(dk_slice).unwrap();
-    let dk = K::DecapsulationKey::from_encoded_bytes(&dk_bytes).unwrap();
+fn verify_decap<K: Decapsulate + EncodedSizeUser>(tc: &acvp::DecapTestCase, dk_slice: &[u8]) {
+    let dk_bytes = Encoded::<K>::try_from(dk_slice).unwrap();
+    let dk = K::from_encoded_bytes(&dk_bytes).unwrap();
 
-    let c = Ciphertext::<K>::try_from(tc.c.as_slice()).unwrap();
+    let c = ::kem::Ciphertext::<K>::try_from(tc.c.as_slice()).unwrap();
     let k = dk.decapsulate(&c);
     assert_eq!(k.as_slice(), tc.k.as_slice());
 }

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -24,7 +24,7 @@ sha3 = { version = "0.11.0-rc.3", default-features = false }
 x25519-dalek = { version = "=3.0.0-pre.4", default-features = false, features = ["static_secrets"] }
 
 # optional dependencies
-zeroize = { version = "1.8.1", optional = true, default-features = true, features = ["zeroize_derive"] }
+zeroize = { version = "1.8.1", optional = true, default-features = true }
 
 [dev-dependencies]
 getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }


### PR DESCRIPTION
Companion PR to RustCrypto/traits#2220

Changes the `Encapsulate` and `Decapsulate` traits to operate on byte arrays instead of generic type parameters. This means all the impls must fully decode their inputs from bytes and encode their outputs to bytes.

`dhkem` was a challenge here since the ciphertext is a curve point and decoding it may result in an error, so RustCrypto/traits#2220 also added a `TryDecapsulate` trait that's fallible (like the trait API was before, but nothing actually needed it until now).

This commit also migrates most of the tests over to using the `kem` traits rather than bespoke traits defined within algorithm-specific crates. Hopefully soon we can just get rid of the latter.