### PR TITLE
ml-kem v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "ml-kem"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "criterion",
  "crypto-common",

--- a/ml-kem/CHANGELOG.md
+++ b/ml-kem/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2 (2026-01-24)
+- Pin `kem` crate dependency to `=0.3.0-pre.0` ([#194])
+
+[#194]: https://github.com/RustCrypto/KEMs/pull/194
+
 ## 0.2.1 (2024-08-17)
 ### Added
 - `zeroize` feature ([#51])

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Module-Lattice-Based Key-Encapsulation Mechanism Standard
 (formerly known as Kyber) as described in FIPS 203
 """
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0 OR MIT"
@@ -22,7 +22,7 @@ deterministic = [] # Expose deterministic generation and encapsulation functions
 zeroize = ["dep:zeroize"]
 
 [dependencies]
-kem = "0.3.0-pre.0"
+kem = "=0.3.0-pre.0"
 hybrid-array = { version = "0.2.0-rc.9", features = ["extra-sizes"] }
 rand_core = "0.6.4"
 sha3 = { version = "0.10.8", default-features = false }


### PR DESCRIPTION
[NOT FOR MERGE: this PR is opened to have one associated with the release, but this is a backport]

Unfortunately `ml-kem` v0.2.0 was released with a dependency on a prerelease version of `kem`: v0.3.0-pre.0.

This is fallout from RustCrypto/traits#2224 where I tried to reuse `kem` v0.3.0-rc* forgetting I had bumped to `kem` v0.4.0-* because of this prerelease dependency used in a stable release.

It seems like at this point since I've gone back to v0.3 we might as well try to make it work. To prevent the stable release of `ml-kem` from picking up new prereleases of `kem` v0.3.0-* containing breaking changes, this pins the `kem` dependency to the version it was released with, i.e. `=0.3.0-pre.0`.

This means it won't be possible to use `ml-kem` v0.2.* and prereleases of `ml-kem` v0.3.0* in the same project, though that will become possible after a stable `ml-kem` v0.3.0 release.