### PR TITLE
Bump `kem` to v0.3.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +66,12 @@ name = "base64ct"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
+
+[[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
@@ -106,9 +118,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.8"
+version = "0.10.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31cd65b2ca03198c223cd9a8fa1152c4ec251cd79049f6dc584152ad3fb5ba9d"
+checksum = "c81d916c6ae06736ec667b51f95ee5ff660a75f4ea6ce1bd932c942365c0ea43"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -281,9 +293,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.21"
+version = "0.7.0-rc.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f9a78b88bb8255ec59a81423aa92ada22f96883f9ae59dcb68613907636ae5"
+checksum = "053c3561863ce55e3226ecc48b08679f4b66cb1b92b9afb42c2c402dfe8b9b51"
 dependencies = [
  "ctutils",
  "hybrid-array",
@@ -295,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.12"
+version = "0.2.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6dcdb44f2c3ee25689ca12a4c19e664fd09f97aeae0bc5043b2dbab6389e308"
+checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -372,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.5"
+version = "0.11.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf9423bafb058e4142194330c52273c343f8a5beb7176d052f0e73b17dd35b9"
+checksum = "2fc1408b7a9f59a7b933faff3e9e7fc15a05a524effd3b3d1601156944c8077f"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -390,9 +402,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.23"
+version = "0.14.0-rc.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660a2eb4d46d49d4c0b122a8cad1fa7926b0e3e99913796243a7dc280021eadc"
+checksum = "5b0f6cc67cc39a00bce2c6f8f8aced0e8c0a06eb1a30f9dd2a9c9f4618bdf3b4"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -437,6 +449,12 @@ name = "find-msvc-tools"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "frodo-kem"
@@ -510,15 +528,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.0-rc.0"
+version = "0.4.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b99f0d993a2b9b97b9a201193aa8ad21305cde06a3be9a7e1f8f4201e5cc27e"
+checksum = "74f70a332ddf75e5e5e43284304179ba02f391f82f692f030b08a8378adf3c99"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "rand_core",
  "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -555,6 +574,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -572,6 +600,12 @@ dependencies = [
  "spin",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -618,13 +652,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -663,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.5"
+version = "0.14.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbe701413868feb2738cda41501dbfa923feede3a8609a2c4ddfa2f86638d5d"
+checksum = "ebb5f9253d4a600323279707ab36a1f1a74d21e85a43f048cce0bfea2928c637"
 dependencies = [
  "cfg-if",
  "elliptic-curve",
@@ -673,22 +715,28 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d546793a04a1d3049bd192856f804cfe96356e2cf36b54b4e575155babe9f41"
+checksum = "5a412fe37705d515cba9dbf1448291a717e187e2351df908cfc0137cbec3d480"
 dependencies = [
  "cpufeatures",
 ]
 
 [[package]]
 name = "kem"
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4584d6b9e14fe98724e721d49f84e203a52a97535ca35b8521857705a356b0f"
+checksum = "1d13ca544bfe26ab1f199a9eef34be41bf06827d0372b35f61846edb9af8d18d"
 dependencies = [
  "crypto-common",
  "rand_core",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -704,6 +752,12 @@ checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -797,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.5"
+version = "0.14.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23920bdbd723052dc68186e64d2c8c2a3b2998b42d61df716f67ef771ce358b"
+checksum = "de1286c2d38465adf5a7d970766796c1fb343172c58fd70f69e8d96e7d9dcbe4"
 dependencies = [
  "elliptic-curve",
  "primefield",
@@ -808,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.5"
+version = "0.14.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8a851b7eed8bfcd741f5dc17c3446eaf8031fa109003fb68f715252cfd4bc9"
+checksum = "3b7574cab645ebcc13db3a531ae853d369e786270efd8b7fdb61de5c9328438d"
 dependencies = [
  "elliptic-curve",
  "fiat-crypto",
@@ -820,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.5"
+version = "0.14.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5121b1f72223718c1ada46b27c60541e6d2d0f886f7526083aa32c2c23d6686e"
+checksum = "aa943740d30f154f6370223a510d5111d08528bf857cb61359048e61983b3eb0"
 dependencies = [
  "base16ct",
  "elliptic-curve",
@@ -909,10 +963,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "primefield"
-version = "0.14.0-rc.5"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90de6476b10bedc43e91337d44440bec88d9c253a1676a046438ba3f5b1d81e"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "primefield"
+version = "0.14.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d00b69a9bd66d09004e2db633068d5af00435f6e673838e50f2944b8033ec8"
 dependencies = [
  "crypto-bigint",
  "crypto-common",
@@ -924,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.5"
+version = "0.14.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77e56adc743d5601fe3a8534fc7c25a28fbbb7470a4f13700e8fdc6817d3a0a"
+checksum = "156aeda78c4a7e86701563514573bc28f127eec880bfa6a22efc4b8139b1c049"
 dependencies = [
  "elliptic-curve",
 ]
@@ -966,9 +1030,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-5"
+version = "0.10.0-rc-6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a06e03bd1f2ae861ab9e7498b6c64ed3dadb9ce175c0464a2522a5f23c0045"
+checksum = "70765ff7112b0fb2d272d24d9a2f907fc206211304328fe58b2db15a5649ef28"
 
 [[package]]
 name = "rayon"
@@ -1065,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-ff"
-version = "0.14.0-pre.0"
+version = "0.14.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9cd37111549306f79b09aa2618e15b1e8241b7178c286821e3dd71579db4db"
+checksum = "36fdf8f956089df8343b9479045c026932f9eb004d0f32d8497b4d133b316a66"
 dependencies = [
  "rand_core",
  "subtle",
@@ -1075,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-group"
-version = "0.14.0-pre.0"
+version = "0.14.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e394cd734b5f97dfc3484fa42aad7acd912961c2bcd96c99aa05b3d6cab7cafd"
+checksum = "df76d08c12814c794ffe95ac788b48081cccb607fade4ed746825d29791ce538"
 dependencies = [
  "rand_core",
  "rustcrypto-ff",
@@ -1227,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
+checksum = "7535f94fa3339fe9e5e9be6260a909e62af97f6e14b32345ccf79b92b8b81233"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1238,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2103ca0e6f4e9505eae906de5e5883e06fc3b2232fb5d6914890c7bbcb62f478"
+checksum = "1deee7fbcdd62fbcffc9dc2f5f17f96adac881ec7e1506e1eedee1644d0cc535"
 dependencies = [
  "digest",
  "keccak",
@@ -1394,6 +1458,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,7 +1491,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.3.1+wasi-0.3.0-rc-2025-09-16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba4be47b1d11244670d11857eee0758a8f2c39aea64d80b78c1ce29b4642cd"
+dependencies = [
+ "wit-bindgen 0.48.1",
 ]
 
 [[package]]
@@ -1467,6 +1546,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01164c9dda68301e34fdae536c23ed6fe90ce6d97213ccc171eebbd3d02d6b8"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876fe286f2fa416386deedebe8407e6f19e0b5aeaef3d03161e77a15fa80f167"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d90019b1afd4b808c263e428de644f3003691f243387d30d673211ee0cb8e8"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1519,6 +1632,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8c2adb5f74ac9395bc3121c99a1254bf9310482c27b13f97167aedb5887138"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b881a098cae03686d7a0587f8f306f8a58102ad8da8b5599100fbe0e7f5800b"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69667efa439a453e1d50dac939c6cab6d2c3ac724a9d232b6631dad2472a5b70"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae2e22cceb5d105d52326c07e3e67603a861cc7add70fc467f7cc7ec5265017"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0c57df25e7ee612d946d3b7646c1ddb2310f8280aa2c17e543b66e0812241"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ef1c6ad67f35c831abd4039c02894de97034100899614d1c44e2268ad01c91"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "x-wing"
 version = "0.1.0-pre.4"
 dependencies = [
@@ -1537,8 +1738,7 @@ dependencies = [
 [[package]]
 name = "x25519-dalek"
 version = "3.0.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5887899407ca8fb861126d509bb08465c14a9c60fad1f24c59ed59630a45586"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek?branch=rand_core%2Fv0.10.0-rc-6#15ee05151ee1d50bba4307a9a4903b2b1b3b057f"
 dependencies = [
  "curve25519-dalek",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ debug = true
 
 [patch.crates-io]
 ml-kem = { path = "./ml-kem" }
+
+x25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek", branch = "rand_core/v0.10.0-rc-6" }

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -14,23 +14,23 @@ keywords = ["crypto", "ecdh", "ecc"]
 readme = "README.md"
 
 [dependencies]
-kem = "0.3.0-rc.0"
-rand_core = "0.10.0-rc-5"
+kem = "0.3.0-rc.2"
+rand_core = "0.10.0-rc-6"
 
 # optional dependencies
-elliptic-curve = { version = "0.14.0-rc.23", optional = true, default-features = false }
-k256 = { version = "0.14.0-rc.5", optional = true, default-features = false, features = ["arithmetic"] }
-p256 = { version = "0.14.0-rc.5", optional = true, default-features = false, features = ["arithmetic"] }
-p384 = { version = "0.14.0-rc.5", optional = true, default-features = false, features = ["arithmetic"] }
-p521 = { version = "0.14.0-rc.5", optional = true, default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.24", optional = true, default-features = false }
+k256 = { version = "0.14.0-rc.6", optional = true, default-features = false, features = ["arithmetic"] }
+p256 = { version = "0.14.0-rc.6", optional = true, default-features = false, features = ["arithmetic"] }
+p384 = { version = "0.14.0-rc.6", optional = true, default-features = false, features = ["arithmetic"] }
+p521 = { version = "0.14.0-rc.6", optional = true, default-features = false, features = ["arithmetic"] }
 x25519 = { version = "=3.0.0-pre.4", package = "x25519-dalek", optional = true, default-features = false }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
+getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
 hex-literal = "1"
 hkdf = "0.13.0-rc.3"
-sha2 = "0.11.0-rc.3"
+sha2 = "0.11.0-rc.4"
 
 [features]
 default = ["zeroize"]

--- a/dhkem/src/ecdh_kem.rs
+++ b/dhkem/src/ecdh_kem.rs
@@ -103,19 +103,19 @@ where
     FieldBytesSize<C>: ModulusSize,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
 {
-    fn encapsulate_with_rng<R: TryCryptoRng + ?Sized>(
-        &self,
-        rng: &mut R,
-    ) -> Result<(Ciphertext<Self>, SharedSecret<Self>), R::Error> {
+    fn encapsulate_with_rng<R>(&self, rng: &mut R) -> (Ciphertext<Self>, SharedSecret<Self>)
+    where
+        R: CryptoRng + ?Sized,
+    {
         // ECDH encapsulation involves creating a new ephemeral key pair and then doing DH
-        let sk = EphemeralSecret::try_generate_from_rng(rng)?;
+        let sk = EphemeralSecret::generate_from_rng(rng);
         let ss = sk.diffie_hellman(&self.0);
 
         // TODO(tarcieri): sk.public_key().to_uncompressed_point()
         let mut pk = UncompressedPoint::<C>::default();
         pk.copy_from_slice(sk.public_key().to_encoded_point(false).as_bytes());
 
-        Ok((pk, ss.raw_secret_bytes().clone()))
+        (pk, ss.raw_secret_bytes().clone())
     }
 }
 

--- a/dhkem/src/x25519_kem.rs
+++ b/dhkem/src/x25519_kem.rs
@@ -70,16 +70,15 @@ impl KeyExport for X25519EncapsulationKey {
 }
 
 impl Encapsulate for X25519EncapsulationKey {
-    fn encapsulate_with_rng<R: TryCryptoRng + ?Sized>(
-        &self,
-        rng: &mut R,
-    ) -> Result<(Ciphertext, SharedSecret), R::Error> {
+    fn encapsulate_with_rng<R>(&self, rng: &mut R) -> (Ciphertext, SharedSecret)
+    where
+        R: CryptoRng + ?Sized,
+    {
         // ECDH encapsulation involves creating a new ephemeral key pair and then doing DH
-        // TODO(tarcieri): don't panic! Fallible `ReusableSecret` generation?
-        let sk = ReusableSecret::random_from_rng(&mut UnwrapErr(rng));
+        let sk = ReusableSecret::random_from_rng(rng);
         let pk = PublicKey::from(&sk);
         let ss = sk.diffie_hellman(&self.0);
-        Ok((pk.to_bytes().into(), ss.to_bytes().into()))
+        (pk.to_bytes().into(), ss.to_bytes().into())
     }
 }
 

--- a/dhkem/tests/hpke_p256_test.rs
+++ b/dhkem/tests/hpke_p256_test.rs
@@ -6,13 +6,13 @@ use elliptic_curve::Generate;
 use hex_literal::hex;
 use hkdf::Hkdf;
 use kem::{Decapsulator, Encapsulate, KeyExport, TryDecapsulate};
-use rand_core::{TryCryptoRng, TryRngCore};
+use rand_core::{TryCryptoRng, TryRng};
 use sha2::Sha256;
 
 /// Constant RNG for testing purposes only.
 struct ConstantRng<'a>(pub &'a [u8]);
 
-impl TryRngCore for ConstantRng<'_> {
+impl TryRng for ConstantRng<'_> {
     type Error = Infallible;
 
     fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
@@ -86,11 +86,9 @@ fn test_dhkem_p256_hkdf_sha256() {
     let pkr = skr.encapsulator();
     assert_eq!(&pkr.to_bytes(), &example_pkr);
 
-    let (pke, ss1) = pkr
-        .encapsulate_with_rng(&mut ConstantRng(&hex!(
-            "4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb"
-        )))
-        .expect("never fails");
+    let (pke, ss1) = pkr.encapsulate_with_rng(&mut ConstantRng(&hex!(
+        "4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb"
+    )));
     assert_eq!(&pke, &example_pke);
 
     let ss2 = skr.try_decapsulate(&pke).unwrap();

--- a/dhkem/tests/tests.rs
+++ b/dhkem/tests/tests.rs
@@ -1,14 +1,17 @@
-use getrandom::SysRng;
+#![cfg(any(
+    feature = "k256",
+    feature = "p256",
+    feature = "p384",
+    feature = "p521",
+    feature = "x25519"
+))]
+
 use kem::{Decapsulator, Encapsulate, Generate, TryDecapsulate};
 
-// we need this because if the crate is compiled with no features this function never
-// gets used
-#[allow(dead_code)]
 fn test_kem<DK: Decapsulator + Generate + TryDecapsulate>() {
-    let mut rng = SysRng;
-    let dk = DK::try_generate_from_rng(&mut SysRng).unwrap();
+    let dk = DK::generate();
     let ek = dk.encapsulator();
-    let (ek, ss1) = ek.encapsulate_with_rng(&mut rng).unwrap();
+    let (ek, ss1) = ek.encapsulate();
     let ss2 = dk.try_decapsulate(&ek).unwrap();
     assert_eq!(ss1.as_slice(), ss2.as_slice());
 }

--- a/frodo-kem/Cargo.toml
+++ b/frodo-kem/Cargo.toml
@@ -58,7 +58,7 @@ serde = ["dep:hex", "dep:serde"]
 aes = { version = "0.9.0-rc.2", optional = true }
 hex = { version = "0.4", optional = true }
 openssl-sys = { version = "0.9.104", optional = true }
-rand_core = { version = "0.10.0-rc-5", features = [] }
+rand_core = { version = "0.10.0-rc-6", features = [] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serdect = "0.4"
 subtle = "2.6"
@@ -80,10 +80,10 @@ zeroize = "1"
 [dev-dependencies]
 aes = "0.9.0-rc.2"
 criterion = "0.7"
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
+getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
 hex = "0.4"
 hybrid-array = "0.4"
-chacha20 = { version = "0.10.0-rc.8", features = ["rng"] }
+chacha20 = { version = "0.10.0-rc.9", features = ["rng"] }
 rstest = "0.26"
 postcard = { version = "1.0", features = ["use-std"] }
 serde_bare = "0.5"

--- a/frodo-kem/src/lib.rs
+++ b/frodo-kem/src/lib.rs
@@ -6,10 +6,9 @@
 //!
 //! ```
 //! use frodo_kem::Algorithm;
-//! use getrandom::SysRng;
-//! use rand_core::TryRngCore;
+//! use getrandom::{SysRng, rand_core::UnwrapErr};
 //!
-//! let mut rng = SysRng.unwrap_err();
+//! let mut rng = UnwrapErr(SysRng);
 //! let alg = Algorithm::FrodoKem640Shake;
 //! let (ek, dk) = alg.generate_keypair(&mut rng);
 //! let (ct, enc_ss) = alg.encapsulate_with_rng(&ek, &mut rng).unwrap();
@@ -29,10 +28,9 @@
 //!
 //! ```
 //! use frodo_kem::Algorithm;
-//! use getrandom::SysRng;
-//! use rand_core::{RngCore, TryRngCore};
+//! use getrandom::{SysRng, rand_core::{Rng, UnwrapErr}};
 //!
-//! let mut rng = SysRng.unwrap_err();
+//! let mut rng = UnwrapErr(SysRng);
 //! let alg = Algorithm::FrodoKem1344Shake;
 //! let params = alg.params();
 //! let (ek, dk) = alg.generate_keypair(&mut rng);
@@ -1634,7 +1632,7 @@ fn ct_eq_bytes(lhs: &[u8], rhs: &[u8]) -> Choice {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use rand_core::{RngCore, SeedableRng};
+    use rand_core::{Rng, SeedableRng};
     use rstest::*;
 
     #[rstest]

--- a/frodo-kem/tests/rng.rs
+++ b/frodo-kem/tests/rng.rs
@@ -6,7 +6,7 @@ use aes::{
 };
 use core::convert::Infallible;
 use hybrid_array::{Array, typenum::U48};
-use rand_core::{RngCore, SeedableRng, TryCryptoRng, TryRngCore};
+use rand_core::{Rng, SeedableRng, TryCryptoRng, TryRng};
 
 /// Seed type for the AES-CTR DRBG
 pub type RngSeed = Array<u8, U48>;
@@ -30,7 +30,7 @@ impl SeedableRng for AesCtrDrbg {
     }
 }
 
-impl TryRngCore for AesCtrDrbg {
+impl TryRng for AesCtrDrbg {
     type Error = Infallible;
 
     fn try_next_u32(&mut self) -> Result<u32, Self::Error> {

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -26,8 +26,8 @@ hazmat = []
 
 [dependencies]
 array = { package = "hybrid-array", version = "0.4.4", features = ["extra-sizes", "subtle"] }
-kem = "0.3.0-rc.0"
-rand_core = "0.10.0-rc-5"
+kem = "0.3.0-rc.2"
+rand_core = "0.10.0-rc-6"
 sha3 = { version = "0.11.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
 
@@ -38,7 +38,7 @@ zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
+getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "1"
 num-rational = { version = "0.4.2", default-features = false, features = ["num-bigint"] }

--- a/ml-kem/benches/mlkem.rs
+++ b/ml-kem/benches/mlkem.rs
@@ -2,10 +2,10 @@ use ::kem::{Decapsulate, Decapsulator, Encapsulate, Generate};
 use criterion::{Criterion, criterion_group, criterion_main};
 use getrandom::SysRng;
 use ml_kem::*;
-use rand_core::TryRngCore;
+use rand_core::UnwrapErr;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let mut rng = SysRng.unwrap_err();
+    let mut rng = UnwrapErr(SysRng);
 
     // Key generation
     c.bench_function("keygen", |b| {
@@ -23,9 +23,9 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     // Encapsulation
     c.bench_function("encapsulate", |b| {
-        b.iter(|| ek.encapsulate_with_rng(&mut rng).unwrap())
+        b.iter(|| ek.encapsulate_with_rng(&mut rng))
     });
-    let (ct, _ss) = ek.encapsulate_with_rng(&mut rng).unwrap();
+    let (ct, _ss) = ek.encapsulate_with_rng(&mut rng);
 
     // Decapsulation
     let dk = <MlKem768 as KemCore>::DecapsulationKey::from_encoded_bytes(&dk_bytes).unwrap();
@@ -41,7 +41,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let dk = ml_kem_768::DecapsulationKey::generate_from_rng(&mut rng);
             let ek = dk.encapsulator();
-            let (ct, _sk) = ek.encapsulate_with_rng(&mut rng).unwrap();
+            let (ct, _sk) = ek.encapsulate_with_rng(&mut rng);
             dk.decapsulate(&ct);
         })
     });

--- a/ml-kem/src/encode.rs
+++ b/ml-kem/src/encode.rs
@@ -144,13 +144,13 @@ where
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
+    use crate::param::EncodedPolynomialVector;
     use array::typenum::{
         U1, U2, U3, U4, U5, U6, U8, U10, U11, U12, marker_traits::Zero, operator_aliases::Mod,
     };
     use core::{fmt::Debug, ops::Rem};
-    use rand_core::{RngCore, TryRngCore};
-
-    use crate::param::EncodedPolynomialVector;
+    use getrandom::SysRng;
+    use rand_core::{Rng, UnwrapErr};
 
     // A helper trait to construct larger arrays by repeating smaller ones
     trait Repeat<T: Clone, D: ArraySize> {
@@ -183,7 +183,7 @@ pub(crate) mod test {
         assert_eq!(&actual_decoded, decoded);
 
         // Test random decode/encode and encode/decode round trips
-        let mut rng = getrandom::SysRng.unwrap_err();
+        let mut rng = UnwrapErr(SysRng);
         let decoded = Array::<Integer, U256>::from_fn(|_| (rng.next_u32() & 0xFFFF) as Integer);
         let m = match D::USIZE {
             12 => FieldElement::Q,

--- a/ml-kem/src/pke.rs
+++ b/ml-kem/src/pke.rs
@@ -207,14 +207,13 @@ mod test {
     use super::*;
     use crate::{MlKem512Params, MlKem768Params, MlKem1024Params};
     use ::kem::Generate;
-    use getrandom::SysRng;
-    use rand_core::TryRngCore;
+    use getrandom::{SysRng, rand_core::UnwrapErr};
 
     fn round_trip_test<P>()
     where
         P: PkeParams,
     {
-        let mut rng = SysRng.unwrap_err();
+        let mut rng = UnwrapErr(SysRng);
         let d = B32::generate_from_rng(&mut rng);
         let original = B32::default();
         let randomness = B32::default();
@@ -236,7 +235,7 @@ mod test {
     where
         P: PkeParams,
     {
-        let mut rng = SysRng.unwrap_err();
+        let mut rng = UnwrapErr(SysRng);
         let d = B32::generate_from_rng(&mut rng);
         let (dk_original, ek_original) = DecryptionKey::<P>::generate(&d);
 

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -19,21 +19,21 @@ zeroize = ["dep:zeroize", "ml-kem/zeroize", "x25519-dalek/zeroize"]
 hazmat = []
 
 [dependencies]
-kem = "0.3.0-rc.0"
+kem = "0.3.0-rc.2"
 ml-kem = { version = "=0.3.0-pre.4", default-features = false, features = ["hazmat"] }
-rand_core = { version = "0.10.0-rc-5", default-features = false }
-sha3 = { version = "0.11.0-rc.3", default-features = false }
+rand_core = { version = "0.10.0-rc-6", default-features = false }
+sha3 = { version = "0.11.0-rc.4", default-features = false }
 x25519-dalek = { version = "=3.0.0-pre.4", default-features = false, features = ["static_secrets"] }
 
 # optional dependencies
 zeroize = { version = "1.8.1", optional = true, default-features = true }
 
 [dev-dependencies]
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
+getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
 hex = { version = "0.4", features = ["serde"] }
-rand_core = "0.10.0-rc-5"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+rand_core = "0.10.0-rc-6"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This includes a `rand_core` v0.10.0-rc-6 bump, which renames `(Try)RngCore` => `(Try)Rng`.

It also makes `enapsulate_with_rng` infallible by accepting a `CryptoRng`.