### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "dhkem"
-version = "0.1.0-pre.1"
+version = "0.1.0-pre.2"
 dependencies = [
  "elliptic-curve",
  "getrandom",
@@ -458,7 +458,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "frodo-kem"
-version = "0.1.0-pre.1"
+version = "0.1.0-pre.2"
 dependencies = [
  "aes",
  "chacha20",
@@ -767,7 +767,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "ml-kem"
-version = "0.3.0-pre.4"
+version = "0.3.0-pre.5"
 dependencies = [
  "const-oid",
  "criterion",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "x-wing"
-version = "0.1.0-pre.4"
+version = "0.1.0-pre.5"
 dependencies = [
  "getrandom",
  "hex",

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of Key Encapsulation Mechanism (KEM) adapters for Elliptic Curve
 Diffie Hellman (ECDH) protocols
 """
-version = "0.1.0-pre.1"
+version = "0.1.0-pre.2"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"

--- a/frodo-kem/Cargo.toml
+++ b/frodo-kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frodo-kem"
-version = "0.1.0-pre.1"
+version = "0.1.0-pre.2"
 description = "Pure Rust implementation of FrodoKEM and eFrodoKEM"
 authors = ["The RustCrypto Team"]
 documentation = "https://docs.rs/frodo-kem"

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Module-Lattice-Based Key-Encapsulation Mechanism Standard
 (formerly known as Kyber) as described in FIPS 203
 """
-version = "0.3.0-pre.4"
+version = "0.3.0-pre.5"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "x-wing"
 description = "Pure Rust implementation of the X-Wing Key Encapsulation Mechanism (draft 06)"
-version = "0.1.0-pre.4"
+version = "0.1.0-pre.5"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -20,7 +20,7 @@ hazmat = []
 
 [dependencies]
 kem = "0.3.0-rc.2"
-ml-kem = { version = "=0.3.0-pre.4", default-features = false, features = ["hazmat"] }
+ml-kem = { version = "=0.3.0-pre.5", default-features = false, features = ["hazmat"] }
 rand_core = { version = "0.10.0-rc-6", default-features = false }
 sha3 = { version = "0.11.0-rc.4", default-features = false }
 x25519-dalek = { version = "=3.0.0-pre.4", default-features = false, features = ["static_secrets"] }


### PR DESCRIPTION
Releases the following:
- `dhkem` v0.1.0-pre.2
- `frodo-kem` v0.1.0-pre.2
- `ml-kem` v0.3.0-pre.5
- `x-wing` v0.1.0-pre.5

cc @karalabe