### PR TITLE
dhkem: remove `DhKem` trait

### DIFF
--- a/dhkem/src/ecdh_kem.rs
+++ b/dhkem/src/ecdh_kem.rs
@@ -1,6 +1,6 @@
 //! Generic Elliptic Curve Diffie-Hellman KEM adapter.
 
-use crate::{DecapsulationKey, DhKem, EncapsulationKey};
+use crate::{DecapsulationKey, EncapsulationKey};
 use core::marker::PhantomData;
 use elliptic_curve::{
     AffinePoint, CurveArithmetic, Error, FieldBytesSize, PublicKey,
@@ -144,27 +144,5 @@ where
         let encapsulated_key = PublicKey::<C>::from_sec1_bytes(encapsulated_key)?;
         let shared_secret = self.dk.diffie_hellman(&encapsulated_key);
         Ok(shared_secret.raw_secret_bytes().clone())
-    }
-}
-
-impl<C> DhKem for EcdhKem<C>
-where
-    C: CurveArithmetic,
-    FieldBytesSize<C>: ModulusSize,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-{
-    type DecapsulatingKey = EcdhDecapsulationKey<C>;
-    type EncapsulatingKey = EcdhEncapsulationKey<C>;
-    type EncapsulatedKey = Ciphertext<EcdhDecapsulationKey<C>>;
-    type SharedSecret = SharedSecret<EcdhDecapsulationKey<C>>;
-
-    fn random_keypair<R: CryptoRng + ?Sized>(
-        rng: &mut R,
-    ) -> (Self::DecapsulatingKey, Self::EncapsulatingKey) {
-        // TODO(tarcieri): propagate RNG errors
-        let sk = EphemeralSecret::try_generate_from_rng(rng).expect("RNG failure");
-        let pk = PublicKey::from(&sk);
-
-        (DecapsulationKey::from(sk), EncapsulationKey(pk))
     }
 }

--- a/dhkem/src/lib.rs
+++ b/dhkem/src/lib.rs
@@ -42,8 +42,6 @@ pub use ecdh_kem::{EcdhDecapsulationKey, EcdhEncapsulationKey, EcdhKem};
 #[cfg(feature = "x25519")]
 pub use x25519_kem::{X25519DecapsulationKey, X25519EncapsulationKey, X25519Kem};
 
-use rand_core::CryptoRng;
-
 #[cfg(feature = "ecdh")]
 use elliptic_curve::{
     CurveArithmetic, PublicKey, bigint,
@@ -141,30 +139,6 @@ impl<DK: Zeroize, EK> Zeroize for DecapsulationKey<DK, EK> {
 
 #[cfg(feature = "zeroize")]
 impl<DK: ZeroizeOnDrop, EK> ZeroizeOnDrop for DecapsulationKey<DK, EK> {}
-
-/// This is a trait that all KEM models should implement, and should probably be
-/// promoted to the kem crate itself. It specifies the types of encapsulating and
-/// decapsulating keys created by key generation, the shared secret type, and the
-/// encapsulated key type
-pub trait DhKem {
-    /// The type that will implement [`TryDecapsulate`]
-    type DecapsulatingKey: Decapsulator + Generate + TryDecapsulate;
-
-    /// The type that will implement [`Encapsulate`]
-    type EncapsulatingKey: Encapsulate;
-
-    /// The type of the encapsulated key
-    type EncapsulatedKey;
-
-    /// The type of the shared secret
-    type SharedSecret;
-
-    /// Generates a new (decapsulating key, encapsulating key) keypair for the KEM
-    /// model
-    fn random_keypair<R: CryptoRng + ?Sized>(
-        rng: &mut R,
-    ) -> (Self::DecapsulatingKey, Self::EncapsulatingKey);
-}
 
 /// NIST P-256 ECDH Decapsulation Key.
 #[cfg(feature = "p256")]

--- a/dhkem/src/x25519_kem.rs
+++ b/dhkem/src/x25519_kem.rs
@@ -1,7 +1,7 @@
-use crate::{DecapsulationKey, DhKem, EncapsulationKey};
+use crate::{DecapsulationKey, EncapsulationKey};
 use kem::{
-    Decapsulate, Decapsulator, Encapsulate, Generate, InvalidKey, KemParams, Key, KeyExport,
-    KeySizeUser, TryKeyInit, common::array::Array, consts::U32,
+    Decapsulate, Encapsulate, Generate, InvalidKey, KemParams, Key, KeyExport, KeySizeUser,
+    TryKeyInit, common::array::Array, consts::U32,
 };
 use rand_core::{CryptoRng, TryCryptoRng, UnwrapErr};
 use x25519::{PublicKey, ReusableSecret};
@@ -95,21 +95,5 @@ impl Decapsulate for X25519DecapsulationKey {
     fn decapsulate(&self, encapsulated_key: &Ciphertext) -> SharedSecret {
         let public_key = PublicKey::from(encapsulated_key.0);
         self.dk.diffie_hellman(&public_key).to_bytes().into()
-    }
-}
-
-impl DhKem for X25519Kem {
-    type DecapsulatingKey = X25519DecapsulationKey;
-    type EncapsulatingKey = X25519EncapsulationKey;
-    type EncapsulatedKey = Ciphertext;
-    type SharedSecret = x25519::SharedSecret;
-
-    fn random_keypair<R>(rng: &mut R) -> (Self::DecapsulatingKey, Self::EncapsulatingKey)
-    where
-        R: CryptoRng + ?Sized,
-    {
-        let dk = Self::DecapsulatingKey::generate_from_rng(rng);
-        let ek = *dk.encapsulator();
-        (dk, ek)
     }
 }


### PR DESCRIPTION
Going forward, we should use traits from the `kem` crate.

It may still make sense to have a trait like this that has the whole KEM type family in one place, possibly called `Kem`, but right now every crate in this repo defines slightly different variants of the same traits and we need to get past that and all get on the same set of traits.