### PR TITLE
ml-kem: define `FieldElement` using `module_lattice::algebra::Elem`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,7 @@ version = "0.1.0-pre.0"
 dependencies = [
  "hybrid-array",
  "num-traits",
+ "subtle",
  "zeroize",
 ]
 

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -21,12 +21,12 @@ alloc = ["pkcs8?/alloc"]
 getrandom = ["kem/getrandom"]
 pem = ["pkcs8/pem"]
 pkcs8 = ["dep:const-oid", "dep:pkcs8"]
-zeroize = ["dep:zeroize"]
+zeroize = ["module-lattice/zeroize", "dep:zeroize"]
 hazmat = []
 
 [dependencies]
 array = { package = "hybrid-array", version = "0.4.4", features = ["extra-sizes", "subtle"] }
-module-lattice = "0.1.0-pre.0"
+module-lattice = { version = "0.1.0-pre.0", features = ["subtle"] }
 kem = "0.3.0-rc.2"
 rand_core = "0.10.0-rc-6"
 sha3 = { version = "0.11.0-rc.3", default-features = false }

--- a/ml-kem/src/param.rs
+++ b/ml-kem/src/param.rs
@@ -10,9 +10,11 @@
 //! know any details about object sizes.  For example, `VectorEncodingSize::flatten` needs to know
 //! that the size of an encoded vector is `K` times the size of an encoded polynomial.
 
-use core::fmt::Debug;
-use core::ops::{Add, Div, Mul, Rem, Sub};
-
+use crate::{
+    B32,
+    algebra::{BaseField, FieldElement, NttVector},
+    encode::Encode,
+};
 use array::{
     Array,
     typenum::{
@@ -21,13 +23,14 @@ use array::{
         type_operators::Gcd,
     },
 };
-
-use crate::{
-    B32,
-    algebra::{FieldElement, NttVector},
-    encode::Encode,
+use core::{
+    fmt::Debug,
+    ops::{Add, Div, Mul, Rem, Sub},
 };
-use module_lattice::util::{Flatten, Unflatten};
+use module_lattice::{
+    algebra::{Elem, Field},
+    util::{Flatten, Unflatten},
+};
 
 #[cfg(doc)]
 use crate::Seed;
@@ -119,7 +122,7 @@ where
     Const<N>: ToUInt<Output = U>,
 {
     let max = 1 << B;
-    let mut out = [FieldElement(0); N];
+    let mut out = [Elem(0); N];
     let mut x = 0usize;
     while x < max {
         let mut y = 0usize;
@@ -128,7 +131,7 @@ where
             let x_ones = x.count_ones() as u16;
             let y_ones = y.count_ones() as u16;
             let i = x + (y << B);
-            out[i] = FieldElement((x_ones + FieldElement::Q - y_ones) % FieldElement::Q);
+            out[i] = Elem((x_ones + BaseField::Q - y_ones) % BaseField::Q);
 
             y += 1;
         }

--- a/module-lattice/Cargo.toml
+++ b/module-lattice/Cargo.toml
@@ -20,7 +20,9 @@ hybrid-array = { version = "0.4", features = ["extra-sizes"] }
 num-traits = { version = "0.2", default-features = false }
 
 # optional dependencies
+subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [features]
+subtle = ["dep:subtle"]
 zeroize = ["hybrid-array/zeroize", "dep:zeroize"]

--- a/module-lattice/src/algebra.rs
+++ b/module-lattice/src/algebra.rs
@@ -5,6 +5,8 @@ use core::ops::{Add, Mul, Neg, Sub};
 use hybrid_array::{Array, ArraySize, typenum::U256};
 use num_traits::PrimInt;
 
+#[cfg(feature = "subtle")]
+use subtle::{Choice, ConstantTimeEq};
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
@@ -80,6 +82,16 @@ pub struct Elem<F: Field>(pub F::Int);
 impl<F: Field> Elem<F> {
     pub const fn new(x: F::Int) -> Self {
         Self(x)
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<F: Field> ConstantTimeEq for Elem<F>
+where
+    F::Int: ConstantTimeEq,
+{
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.ct_eq(&other.0)
     }
 }
 


### PR DESCRIPTION
Replaces the `FieldElement` defined in the `ml-kem` crate using one defined with the `Elem` type from the `module-lattice` crate, namely as a type alias thereof.

This is the first step towards actually using the generic implementation shared with the `ml-dsa` crate.

This necessitated adding a `subtle` feature to `module-lattice` so we can define `ConstantTimeEq` on `Elem`.

Uses the `module_lattice::define_field!` macro to define a new `BaseField` type for `ml-kem`, using the modulus 3329, which replaces several inherent constants previously defined on `Field`.

The previous `FieldElement::base_case_multiply` method was turned into a private free function within `algebra`, since we can't define an inherent method on an external type.