### PR TITLE
module-lattice: add preliminary `small_reduce` test

### DIFF
--- a/.github/workflows/module-lattice.yml
+++ b/.github/workflows/module-lattice.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           toolchain: stable
           targets: thumbv7em-none-eabi
-      - run: cargo check --target thumbv7em-none-eabi --release
+      - run: cargo check --target thumbv7em-none-eabi --all-features --release
 
   test:
     needs: set-msrv
@@ -58,4 +58,5 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - run: cargo test
-      - run: cargo test --release
+      - run: cargo test --all-features
+      - run: cargo test --all-features --release

--- a/module-lattice/src/algebra.rs
+++ b/module-lattice/src/algebra.rs
@@ -42,7 +42,7 @@ macro_rules! define_field {
         #[derive(Copy, Clone, Default, Debug, PartialEq)]
         pub struct $field;
 
-        impl Field for $field {
+        impl $crate::algebra::Field for $field {
             type Int = $int;
             type Long = $long;
             type LongLong = $longlong;
@@ -65,7 +65,7 @@ macro_rules! define_field {
                 let product = x * Self::BARRETT_MULTIPLIER;
                 let quotient = product >> Self::BARRETT_SHIFT;
                 let remainder = x - quotient * Self::QLL;
-                Self::small_reduce(Truncate::truncate(remainder))
+                Self::small_reduce($crate::util::Truncate::truncate(remainder))
             }
         }
     };

--- a/module-lattice/tests/algebra.rs
+++ b/module-lattice/tests/algebra.rs
@@ -1,0 +1,18 @@
+//! Tests for the `algebra` module.
+
+use module_lattice::algebra::Field;
+
+// Field used by ML-KEM.
+module_lattice::define_field!(KyberField, u16, u32, u64, 3329);
+
+// Field used by ML-DSA.
+module_lattice::define_field!(DilithiumField, u32, u64, u128, 8_380_417);
+
+#[test]
+fn small_reduce() {
+    assert_eq!(KyberField::small_reduce(3328), 3328);
+    assert_eq!(KyberField::small_reduce(3329), 0);
+
+    assert_eq!(DilithiumField::small_reduce(8_380_416), 8_380_416);
+    assert_eq!(DilithiumField::small_reduce(8_380_417), 0);
+}


### PR DESCRIPTION
Begins adding tests by adding a `tests/algebra.rs` and using `module_lattice::define_field!` to define both the ML-KEM/Kyber and ML-DSA/Dilithium fields.

Uses this to write a simple test for `small_reduce` which tests how reduction is handled around the boundary conditions of the modulus.