### PR TITLE
ml-kem: zeroize seed value of `DecapsulationKey` on drop

### DIFF
--- a/ml-kem/src/kem.rs
+++ b/ml-kem/src/kem.rs
@@ -57,9 +57,7 @@ where
 {
     fn drop(&mut self) {
         self.dk_pke.zeroize();
-        if let Some(d) = self.d.as_mut() {
-            d.zeroize();
-        }
+        self.d.zeroize();
         self.z.zeroize();
     }
 }


### PR DESCRIPTION
FIPS 203 section 3.3 **Destruction of intermediate values**:

> The seed (𝑑, 𝑧) generated in steps 1 and 2 of ML-KEM.KeyGen can be stored for later
expansion using ML-KEM.KeyGen_internal. As this seed can be used to compute the
decapsulation key, it is sensitive data and shall be treated with the same safeguards as a
decapsulation key (see SP 800-227 [1]).

Since decapsulation keys are zeroized on drop, 𝑑 should be, to