### PR TITLE
ml-kem: use `FieldElement::new` to construct field elements

### DIFF
--- a/.github/workflows/ml-kem.yml
+++ b/.github/workflows/ml-kem.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/ml-kem.yml"
       - "ml-kem/**"
+      - "module-lattice/**"
       - "Cargo.*"
   push:
     branches: master

--- a/ml-kem/src/compress.rs
+++ b/ml-kem/src/compress.rs
@@ -90,7 +90,6 @@ impl<K: ArraySize> Compress for PolynomialVector<K> {
 pub(crate) mod test {
     use super::*;
     use array::typenum::{U1, U4, U5, U6, U10, U11, U12};
-    use module_lattice::algebra::Elem;
     use num_rational::Ratio;
 
     #[allow(clippy::cast_possible_truncation)]
@@ -112,7 +111,7 @@ pub(crate) mod test {
         let error_threshold = i32::from(Ratio::new(BaseField::Q, 1 << D::USIZE).to_integer());
 
         for x in 0..BaseField::Q {
-            let mut y = Elem(x);
+            let mut y = FieldElement::new(x);
             y.compress::<D>();
             y.decompress::<D>();
 
@@ -132,7 +131,7 @@ pub(crate) mod test {
 
     fn decompression_compression_equality<D: CompressionFactor>() {
         for x in 0..(1 << D::USIZE) {
-            let mut y = Elem(x);
+            let mut y = FieldElement::new(x);
             y.decompress::<D>();
             y.compress::<D>();
 
@@ -143,7 +142,7 @@ pub(crate) mod test {
     fn decompress_KAT<D: CompressionFactor>() {
         for y in 0..(1 << D::USIZE) {
             let x_expected = rational_decompress::<D>(y);
-            let mut x_actual = Elem(y);
+            let mut x_actual = FieldElement::new(y);
             x_actual.decompress::<D>();
 
             assert_eq!(x_expected, x_actual.0);
@@ -153,7 +152,7 @@ pub(crate) mod test {
     fn compress_KAT<D: CompressionFactor>() {
         for x in 0..BaseField::Q {
             let y_expected = rational_compress::<D>(x);
-            let mut y_actual = Elem(x);
+            let mut y_actual = FieldElement::new(x);
             y_actual.compress::<D>();
 
             assert_eq!(y_expected, y_actual.0, "for x: {}, D: {}", x, D::USIZE);

--- a/ml-kem/src/encode.rs
+++ b/ml-kem/src/encode.rs
@@ -151,7 +151,6 @@ pub(crate) mod test {
     };
     use core::{fmt::Debug, ops::Rem};
     use getrandom::SysRng;
-    use module_lattice::algebra::Elem;
     use module_lattice::algebra::Field;
     use rand_core::{Rng, UnwrapErr};
 
@@ -192,7 +191,7 @@ pub(crate) mod test {
             12 => BaseField::Q,
             d => (1 as Integer) << d,
         };
-        let decoded = decoded.iter().map(|x| Elem(x % m)).collect();
+        let decoded = decoded.iter().map(|x| FieldElement::new(x % m)).collect();
 
         let actual_encoded = byte_encode::<D>(&decoded);
         let actual_decoded = byte_decode::<D>(&actual_encoded);
@@ -205,20 +204,21 @@ pub(crate) mod test {
     #[test]
     fn byte_codec() {
         // The 1-bit can only represent decoded values equal to 0 or 1.
-        let decoded: DecodedValue = Array::<_, U2>([Elem(0), Elem(1)]).repeat();
+        let decoded: DecodedValue =
+            Array::<_, U2>([FieldElement::new(0), FieldElement::new(1)]).repeat();
         let encoded: EncodedPolynomial<U1> = Array([0xaa; 32]);
         byte_codec_test::<U1>(&decoded, &encoded);
 
         // For other codec widths, we use a standard sequence
         let decoded: DecodedValue = Array::<_, U8>([
-            Elem(0),
-            Elem(1),
-            Elem(2),
-            Elem(3),
-            Elem(4),
-            Elem(5),
-            Elem(6),
-            Elem(7),
+            FieldElement::new(0),
+            FieldElement::new(1),
+            FieldElement::new(2),
+            FieldElement::new(3),
+            FieldElement::new(4),
+            FieldElement::new(5),
+            FieldElement::new(6),
+            FieldElement::new(7),
         ])
         .repeat();
 
@@ -255,7 +255,7 @@ pub(crate) mod test {
     fn byte_codec_12_mod() {
         // DecodeBytes_12 is required to reduce mod q
         let encoded: EncodedPolynomial<U12> = Array([0xff; 384]);
-        let decoded: DecodedValue = Array([Elem(0xfff % BaseField::Q); 256]);
+        let decoded: DecodedValue = Array([FieldElement::new(0xfff % BaseField::Q); 256]);
 
         let actual_decoded = byte_decode::<U12>(&encoded);
         assert_eq!(actual_decoded, decoded);
@@ -277,14 +277,14 @@ pub(crate) mod test {
     fn vector_codec() {
         let poly = Polynomial(
             Array::<_, U8>([
-                Elem(0),
-                Elem(1),
-                Elem(2),
-                Elem(3),
-                Elem(4),
-                Elem(5),
-                Elem(6),
-                Elem(7),
+                FieldElement::new(0),
+                FieldElement::new(1),
+                FieldElement::new(2),
+                FieldElement::new(3),
+                FieldElement::new(4),
+                FieldElement::new(5),
+                FieldElement::new(6),
+                FieldElement::new(7),
             ])
             .repeat(),
         );

--- a/ml-kem/src/param.rs
+++ b/ml-kem/src/param.rs
@@ -28,7 +28,7 @@ use core::{
     ops::{Add, Div, Mul, Rem, Sub},
 };
 use module_lattice::{
-    algebra::{Elem, Field},
+    algebra::Field,
     util::{Flatten, Unflatten},
 };
 
@@ -122,7 +122,7 @@ where
     Const<N>: ToUInt<Output = U>,
 {
     let max = 1 << B;
-    let mut out = [Elem(0); N];
+    let mut out = [FieldElement::new(0); N];
     let mut x = 0usize;
     while x < max {
         let mut y = 0usize;
@@ -131,7 +131,7 @@ where
             let x_ones = x.count_ones() as u16;
             let y_ones = y.count_ones() as u16;
             let i = x + (y << B);
-            out[i] = Elem((x_ones + BaseField::Q - y_ones) % BaseField::Q);
+            out[i] = FieldElement::new((x_ones + BaseField::Q - y_ones) % BaseField::Q);
 
             y += 1;
         }


### PR DESCRIPTION
Instead of using `Elem(x)` which is confusing due to the different name.