### PR TITLE
ml-kem: use `Polynomial(Vector)` from `module-lattice`

### DIFF
--- a/ml-kem/src/encode.rs
+++ b/ml-kem/src/encode.rs
@@ -275,7 +275,7 @@ pub(crate) mod test {
 
     #[test]
     fn vector_codec() {
-        let poly = Polynomial(
+        let poly = Polynomial::new(
             Array::<_, U8>([
                 FieldElement::new(0),
                 FieldElement::new(1),
@@ -290,17 +290,17 @@ pub(crate) mod test {
         );
 
         // The required vector sizes are 2, 3, and 4.
-        let decoded: PolynomialVector<U2> = PolynomialVector(Array([poly, poly]));
+        let decoded: PolynomialVector<U2> = PolynomialVector::new(Array([poly, poly]));
         let encoded: EncodedPolynomialVector<U5, U2> =
             Array::<_, U5>([0x20, 0x88, 0x41, 0x8a, 0x39]).repeat();
         vector_codec_known_answer_test::<U5, PolynomialVector<U2>>(&decoded, &encoded);
 
-        let decoded: PolynomialVector<U3> = PolynomialVector(Array([poly, poly, poly]));
+        let decoded: PolynomialVector<U3> = PolynomialVector::new(Array([poly, poly, poly]));
         let encoded: EncodedPolynomialVector<U5, U3> =
             Array::<_, U5>([0x20, 0x88, 0x41, 0x8a, 0x39]).repeat();
         vector_codec_known_answer_test::<U5, PolynomialVector<U3>>(&decoded, &encoded);
 
-        let decoded: PolynomialVector<U4> = PolynomialVector(Array([poly, poly, poly, poly]));
+        let decoded: PolynomialVector<U4> = PolynomialVector::new(Array([poly, poly, poly, poly]));
         let encoded: EncodedPolynomialVector<U5, U4> =
             Array::<_, U5>([0x20, 0x88, 0x41, 0x8a, 0x39]).repeat();
         vector_codec_known_answer_test::<U5, PolynomialVector<U4>>(&decoded, &encoded);

--- a/module-lattice/src/algebra.rs
+++ b/module-lattice/src/algebra.rs
@@ -143,7 +143,7 @@ impl<F: Field> Mul<Elem<F>> for Elem<F> {
 /// A `Polynomial` is a member of the ring `R_q = Z_q[X] / (X^256)` of degree-256 polynomials
 /// over the finite field with prime order `q`.  Polynomials can be added, subtracted, negated,
 /// and multiplied by field elements.  We do not define multiplication of polynomials here.
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
 pub struct Polynomial<F: Field>(pub Array<Elem<F>, U256>);
 
 impl<F: Field> Polynomial<F> {
@@ -227,6 +227,12 @@ where
     }
 }
 
+impl<F: Field, K: ArraySize> Add<Vector<F, K>> for Vector<F, K> {
+    type Output = Vector<F, K>;
+    fn add(self, rhs: Vector<F, K>) -> Vector<F, K> {
+        Add::add(&self, &rhs)
+    }
+}
 impl<F: Field, K: ArraySize> Add<&Vector<F, K>> for &Vector<F, K> {
     type Output = Vector<F, K>;
 


### PR DESCRIPTION
Replaces the `Polynomial` and `PolynomialVector` types defined in `ml-kem` with shared implementations with `ml-dsa` from the `module-lattice` crate.