### PR TITLE
ml-kem: use `NttPolynomial` from `module-lattice`

### DIFF
--- a/ml-kem/src/pke.rs
+++ b/ml-kem/src/pke.rs
@@ -1,6 +1,6 @@
 use crate::B32;
 use crate::algebra::{
-    NttMatrix, NttVector, Polynomial, PolynomialVector, ntt_vector, sample_poly_cbd,
+    NttMatrix, NttVector, Polynomial, PolynomialVector, ntt_inverse, ntt_vector, sample_poly_cbd,
     sample_poly_vec_cbd,
 };
 use crate::compress::Compress;
@@ -95,7 +95,7 @@ where
         v.decompress::<P::Dv>();
 
         let u_hat = ntt_vector(&u);
-        let sTu = (&self.s_hat * &u_hat).ntt_inverse();
+        let sTu = ntt_inverse(&(&self.s_hat * &u_hat));
         let mut w = &v - &sTu;
         Encode::<U1>::encode(w.compress::<U1>())
     }
@@ -144,7 +144,7 @@ where
         let mut mu: Polynomial = Encode::<U1>::decode(message);
         mu.decompress::<U1>();
 
-        let tTr: Polynomial = (&self.t_hat * &r_hat).ntt_inverse();
+        let tTr: Polynomial = ntt_inverse(&(&self.t_hat * &r_hat));
         let mut v = &(&tTr + &e2) + &mu;
 
         let c1 = Encode::<P::Du>::encode(u.compress::<P::Du>());

--- a/module-lattice/src/algebra.rs
+++ b/module-lattice/src/algebra.rs
@@ -291,16 +291,6 @@ impl<F: Field> NttPolynomial<F> {
     }
 }
 
-#[cfg(feature = "zeroize")]
-impl<F: Field> Zeroize for NttPolynomial<F>
-where
-    F::Int: Zeroize,
-{
-    fn zeroize(&mut self) {
-        self.0.zeroize();
-    }
-}
-
 impl<F: Field> Add<&NttPolynomial<F>> for &NttPolynomial<F> {
     type Output = NttPolynomial<F>;
 
@@ -357,6 +347,38 @@ impl<F: Field> Neg for &NttPolynomial<F> {
 
     fn neg(self) -> NttPolynomial<F> {
         NttPolynomial(self.0.iter().map(|&x| -x).collect())
+    }
+}
+
+impl<F: Field> From<Array<Elem<F>, U256>> for NttPolynomial<F> {
+    fn from(f: Array<Elem<F>, U256>) -> NttPolynomial<F> {
+        NttPolynomial(f)
+    }
+}
+
+impl<F: Field> From<NttPolynomial<F>> for Array<Elem<F>, U256> {
+    fn from(f_hat: NttPolynomial<F>) -> Array<Elem<F>, U256> {
+        f_hat.0
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<F: Field> ConstantTimeEq for NttPolynomial<F>
+where
+    F::Int: ConstantTimeEq,
+{
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.ct_eq(&other.0)
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<F: Field> Zeroize for NttPolynomial<F>
+where
+    F::Int: Zeroize,
+{
+    fn zeroize(&mut self) {
+        self.0.zeroize();
     }
 }
 


### PR DESCRIPTION
It seems `module-lattice` has a `Mul` impl for `NttPolynomial` that implements ML-DSA's `MultiplyNTT` which seems incompatible with the one in `ml-kem` that defines its own `MultiplyNTTs` (Algorithm 11) which is used here instead.

It perhaps suggests that code should be factored into `ml-dsa`.