### PR TITLE
ml-kem/module-lattice: add traits for NTT operations

### DIFF
--- a/ml-kem/src/pke.rs
+++ b/ml-kem/src/pke.rs
@@ -1,6 +1,6 @@
 use crate::B32;
 use crate::algebra::{
-    NttMatrix, NttVector, Polynomial, PolynomialVector, ntt_inverse, ntt_vector, sample_poly_cbd,
+    Ntt, NttInverse, NttMatrix, NttVector, Polynomial, PolynomialVector, sample_poly_cbd,
     sample_poly_vec_cbd,
 };
 use crate::compress::Compress;
@@ -71,8 +71,8 @@ where
         let e: PolynomialVector<P::K> = sample_poly_vec_cbd::<P::Eta1, P::K>(&sigma, P::K::U8);
 
         // NTT the vectors
-        let s_hat = ntt_vector(&s);
-        let e_hat = ntt_vector(&e);
+        let s_hat = s.ntt();
+        let e_hat = e.ntt();
 
         // Compute the public value
         let t_hat = &(&A_hat * &s_hat) + &e_hat;
@@ -94,8 +94,8 @@ where
         let mut v: Polynomial = Encode::<P::Dv>::decode(c2);
         v.decompress::<P::Dv>();
 
-        let u_hat = ntt_vector(&u);
-        let sTu = ntt_inverse(&(&self.s_hat * &u_hat));
+        let u_hat = u.ntt();
+        let sTu = (&self.s_hat * &u_hat).ntt_inverse();
         let mut w = &v - &sTu;
         Encode::<U1>::encode(w.compress::<U1>())
     }
@@ -137,14 +137,14 @@ where
         let e2: Polynomial = sample_poly_cbd::<P::Eta2>(&prf_output);
 
         let A_hat_t = NttMatrix::<P::K>::sample_uniform(&self.rho, true);
-        let r_hat: NttVector<P::K> = ntt_vector(&r);
+        let r_hat: NttVector<P::K> = r.ntt();
         let ATr: PolynomialVector<P::K> = (&A_hat_t * &r_hat).ntt_inverse();
         let mut u = ATr + e1;
 
         let mut mu: Polynomial = Encode::<U1>::decode(message);
         mu.decompress::<U1>();
 
-        let tTr: Polynomial = ntt_inverse(&(&self.t_hat * &r_hat));
+        let tTr: Polynomial = (&self.t_hat * &r_hat).ntt_inverse();
         let mut v = &(&tTr + &e2) + &mu;
 
         let c1 = Encode::<P::Du>::encode(u.compress::<P::Du>());

--- a/module-lattice/src/algebra.rs
+++ b/module-lattice/src/algebra.rs
@@ -327,19 +327,20 @@ impl<F: Field> Mul<&NttPolynomial<F>> for Elem<F> {
     }
 }
 
-impl<F: Field> Mul<&NttPolynomial<F>> for &NttPolynomial<F> {
+impl<F> Mul<&NttPolynomial<F>> for &NttPolynomial<F>
+where
+    F: Field + MultiplyNtt,
+{
     type Output = NttPolynomial<F>;
 
-    // Algorithm 45 MultiplyNTT
     fn mul(self, rhs: &NttPolynomial<F>) -> NttPolynomial<F> {
-        NttPolynomial::new(
-            self.0
-                .iter()
-                .zip(rhs.0.iter())
-                .map(|(&x, &y)| x * y)
-                .collect(),
-        )
+        F::multiply_ntt(self, rhs)
     }
+}
+
+/// Perform multiplication in the NTT domain.
+pub trait MultiplyNtt: Field {
+    fn multiply_ntt(lhs: &NttPolynomial<Self>, rhs: &NttPolynomial<Self>) -> NttPolynomial<Self>;
 }
 
 impl<F: Field> Neg for &NttPolynomial<F> {


### PR DESCRIPTION
Adds `MultiplyNtt` to `module-lattice`, and `Ntt` and `NttInverse` to `ml-kem`.

Previously `module-lattice` defined the `Mul` impl on `NttPolynomial` in terms of Algorithm 45 from FIPS 204, and this is used by the `Mul` impls on `NttVector` and `NttMatrix` as well.

For ML-KEM we instead need to plug in Algorithm 11 from FIPS 203 (MultiplyNTTs), so we need a trait that lets each crate define the `Mul` impl on `NttPolynomial`.

This adds a `MultiplyNtt` trait to `module-lattice`, currently defined on a `Field` (perhaps not great but it's the generic parameter we have), which allows each construction to plug in their own NTT multiplication algorithm.

The existing implementation of Algorithm 45 from FIPS 204 will need to move to the `ml-dsa` crate.

Also, following the structure of the `ml-dsa` crate, this defines two same-shaped traits, `Ntt` and `NttInverse`, that can be impl'd on types from `module-lattice` to use the same method syntax that was being used previously before #210.

Unfortunately we can't share traits with `ml-dsa`, because the only way we can impl these traits for types from `module-lattice` is if we define them. But they're small and there aren't that many of them.