### PR TITLE
ml-kem: align type names with `module-lattice`/`ml-dsa`

### DIFF
--- a/ml-kem/src/param.rs
+++ b/ml-kem/src/param.rs
@@ -12,7 +12,7 @@
 
 use crate::{
     B32,
-    algebra::{BaseField, FieldElement, NttVector},
+    algebra::{BaseField, Elem, NttVector},
     encode::Encode,
 };
 use array::{
@@ -104,7 +104,7 @@ where
 pub trait CbdSamplingSize: ArraySize {
     type SampleSize: EncodingSize;
     type OnesSize: ArraySize;
-    const ONES: Array<FieldElement, Self::OnesSize>;
+    const ONES: Array<Elem, Self::OnesSize>;
 }
 
 // To speed up CBD sampling, we pre-compute all the bit-manipulations:
@@ -116,13 +116,13 @@ pub trait CbdSamplingSize: ArraySize {
 // We have to allow the use of `as` here because we can't use our nice Truncate trait, because
 // const functions don't support traits.
 #[allow(clippy::cast_possible_truncation)]
-const fn ones_array<const B: usize, const N: usize, U>() -> Array<FieldElement, U>
+const fn ones_array<const B: usize, const N: usize, U>() -> Array<Elem, U>
 where
-    U: ArraySize<ArrayType<FieldElement> = [FieldElement; N]>,
+    U: ArraySize<ArrayType<Elem> = [Elem; N]>,
     Const<N>: ToUInt<Output = U>,
 {
     let max = 1 << B;
-    let mut out = [FieldElement::new(0); N];
+    let mut out = [Elem::new(0); N];
     let mut x = 0usize;
     while x < max {
         let mut y = 0usize;
@@ -131,7 +131,7 @@ where
             let x_ones = x.count_ones() as u16;
             let y_ones = y.count_ones() as u16;
             let i = x + (y << B);
-            out[i] = FieldElement::new((x_ones + BaseField::Q - y_ones) % BaseField::Q);
+            out[i] = Elem::new((x_ones + BaseField::Q - y_ones) % BaseField::Q);
 
             y += 1;
         }
@@ -143,13 +143,13 @@ where
 impl CbdSamplingSize for U2 {
     type SampleSize = U4;
     type OnesSize = U16;
-    const ONES: Array<FieldElement, U16> = ones_array::<2, 16, U16>();
+    const ONES: Array<Elem, U16> = ones_array::<2, 16, U16>();
 }
 
 impl CbdSamplingSize for U3 {
     type SampleSize = U6;
     type OnesSize = U64;
-    const ONES: Array<FieldElement, U64> = ones_array::<3, 64, U64>();
+    const ONES: Array<Elem, U64> = ones_array::<3, 64, U64>();
 }
 
 /// A `ParameterSet` captures the parameters that describe a particular instance of ML-KEM.  There

--- a/ml-kem/src/pke.rs
+++ b/ml-kem/src/pke.rs
@@ -1,7 +1,6 @@
 use crate::B32;
 use crate::algebra::{
-    Ntt, NttInverse, NttMatrix, NttVector, Polynomial, PolynomialVector, sample_poly_cbd,
-    sample_poly_vec_cbd,
+    Ntt, NttInverse, NttMatrix, NttVector, Polynomial, Vector, sample_poly_cbd, sample_poly_vec_cbd,
 };
 use crate::compress::Compress;
 use crate::crypto::{G, PRF};
@@ -67,8 +66,8 @@ where
 
         // Sample pseudo-random matrix and vectors
         let A_hat: NttMatrix<P::K> = NttMatrix::sample_uniform(&rho, false);
-        let s: PolynomialVector<P::K> = sample_poly_vec_cbd::<P::Eta1, P::K>(&sigma, 0);
-        let e: PolynomialVector<P::K> = sample_poly_vec_cbd::<P::Eta1, P::K>(&sigma, P::K::U8);
+        let s: Vector<P::K> = sample_poly_vec_cbd::<P::Eta1, P::K>(&sigma, 0);
+        let e: Vector<P::K> = sample_poly_vec_cbd::<P::Eta1, P::K>(&sigma, P::K::U8);
 
         // NTT the vectors
         let s_hat = s.ntt();
@@ -88,7 +87,7 @@ where
     pub fn decrypt(&self, ciphertext: &EncodedCiphertext<P>) -> B32 {
         let (c1, c2) = P::split_ct(ciphertext);
 
-        let mut u: PolynomialVector<P::K> = Encode::<P::Du>::decode(c1);
+        let mut u: Vector<P::K> = Encode::<P::Du>::decode(c1);
         u.decompress::<P::Du>();
 
         let mut v: Polynomial = Encode::<P::Dv>::decode(c2);
@@ -138,7 +137,7 @@ where
 
         let A_hat_t = NttMatrix::<P::K>::sample_uniform(&self.rho, true);
         let r_hat: NttVector<P::K> = r.ntt();
-        let ATr: PolynomialVector<P::K> = (&A_hat_t * &r_hat).ntt_inverse();
+        let ATr: Vector<P::K> = (&A_hat_t * &r_hat).ntt_inverse();
         let mut u = ATr + e1;
 
         let mut mu: Polynomial = Encode::<U1>::decode(message);


### PR DESCRIPTION
Changes the type aliases defined in `algebra.rs` to have the same names as the types in `module-lattice`, just sans the generic `F: Field` parameter.

This same approach is the one used in `ml-dsa`.