### PR TITLE
ml-kem: use `NttMatrix` from `module-lattice`

### DIFF
--- a/ml-kem/src/pke.rs
+++ b/ml-kem/src/pke.rs
@@ -1,6 +1,7 @@
 use crate::B32;
 use crate::algebra::{
-    Ntt, NttInverse, NttMatrix, NttVector, Polynomial, Vector, sample_poly_cbd, sample_poly_vec_cbd,
+    Ntt, NttInverse, NttMatrix, NttVector, Polynomial, Vector, matrix_sample_ntt, sample_poly_cbd,
+    sample_poly_vec_cbd,
 };
 use crate::compress::Compress;
 use crate::crypto::{G, PRF};
@@ -65,7 +66,7 @@ where
         let (rho, sigma) = G(&[&d[..], &[k]]);
 
         // Sample pseudo-random matrix and vectors
-        let A_hat: NttMatrix<P::K> = NttMatrix::sample_uniform(&rho, false);
+        let A_hat: NttMatrix<P::K> = matrix_sample_ntt(&rho, false);
         let s: Vector<P::K> = sample_poly_vec_cbd::<P::Eta1, P::K>(&sigma, 0);
         let e: Vector<P::K> = sample_poly_vec_cbd::<P::Eta1, P::K>(&sigma, P::K::U8);
 
@@ -135,7 +136,7 @@ where
         let prf_output = PRF::<P::Eta2>(randomness, 2 * P::K::U8);
         let e2: Polynomial = sample_poly_cbd::<P::Eta2>(&prf_output);
 
-        let A_hat_t = NttMatrix::<P::K>::sample_uniform(&self.rho, true);
+        let A_hat_t: NttMatrix<P::K> = matrix_sample_ntt(&self.rho, true);
         let r_hat: NttVector<P::K> = r.ntt();
         let ATr: Vector<P::K> = (&A_hat_t * &r_hat).ntt_inverse();
         let mut u = ATr + e1;


### PR DESCRIPTION
This is the last type which was previously defined in `algebra.rs` that needed to be converted to the generic implementation.