### PR TITLE
dhkem: impl `(Try)KeyInit`/`KeyExport` for `DecapsulationKey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,8 +403,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0f6cc67cc39a00bce2c6f8f8aced0e8c0a06eb1a30f9dd2a9c9f4618bdf3b4"
+source = "git+https://github.com/RustCrypto/traits#43d020754c46cd81ca8d13c980f48215aa362627"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,5 @@ debug = true
 [patch.crates-io]
 ml-kem = { path = "./ml-kem" }
 module-lattice = { path = "./module-lattice" }
+
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -41,7 +41,7 @@ k256 = ["dep:k256", "ecdh"]
 p256 = ["dep:p256", "ecdh"]
 p384 = ["dep:p384", "ecdh"]
 p521 = ["dep:p521", "ecdh"]
-x25519 = ["dep:x25519", "x25519/reusable_secrets"]
+x25519 = ["dep:x25519", "x25519/static_secrets"]
 zeroize = ["dep:zeroize"]
 
 [package.metadata.docs.rs]

--- a/dhkem/src/x25519_kem.rs
+++ b/dhkem/src/x25519_kem.rs
@@ -1,20 +1,11 @@
 use crate::{DecapsulationKey, EncapsulationKey};
 use kem::{
-    Decapsulate, Encapsulate, Generate, InvalidKey, Kem, Key, KeyExport, KeySizeUser, TryKeyInit,
-    common::array::Array, consts::U32,
+    Decapsulate, Encapsulate, Generate, InvalidKey, Kem, Key, KeyExport, KeyInit, KeySizeUser,
+    TryKeyInit,
+    common::array::{Array, sizes::U32},
 };
-use rand_core::{CryptoRng, TryCryptoRng, UnwrapErr};
-use x25519::{PublicKey, ReusableSecret};
-
-/// Elliptic Curve Diffie-Hellman Decapsulation Key (i.e. secret decryption key)
-///
-/// Generic around an elliptic curve `C`.
-pub type X25519DecapsulationKey = DecapsulationKey<ReusableSecret, PublicKey>;
-
-/// Elliptic Curve Diffie-Hellman Encapsulation Key (i.e. public encryption key)
-///
-/// Generic around an elliptic curve `C`.
-pub type X25519EncapsulationKey = EncapsulationKey<PublicKey>;
+use rand_core::{CryptoRng, TryCryptoRng};
+use x25519::{PublicKey, StaticSecret};
 
 /// X25519 ciphertexts are compressed Montgomery x/u-coordinates.
 type Ciphertext = Array<u8, U32>;
@@ -34,6 +25,59 @@ impl Kem for X25519Kem {
     type CiphertextSize = U32;
     type SharedKeySize = U32;
 }
+
+/// Elliptic Curve Diffie-Hellman Decapsulation Key (i.e. secret decryption key)
+///
+/// Generic around an elliptic curve `C`.
+pub type X25519DecapsulationKey = DecapsulationKey<StaticSecret, PublicKey>;
+
+impl KeySizeUser for X25519DecapsulationKey {
+    type KeySize = U32;
+}
+
+/// From [RFC9810 §7.1.2]: `SerializePrivateKey` and `DeserializePrivateKey`:
+///
+/// > For X25519 and X448, private keys are identical to their byte string representation,
+/// > so little processing has to be done. [...]
+/// > DeserializePrivateKey() function MUST clamp its input
+///
+/// [RFC9810 §7.1.2]: https://datatracker.ietf.org/doc/html/rfc9180#section-7.1.2
+impl KeyInit for X25519DecapsulationKey {
+    fn new(key: &Key<Self>) -> Self {
+        StaticSecret::from(key.0).into()
+    }
+}
+
+/// From [RFC9810 §7.1.2]: `SerializePrivateKey` and `DeserializePrivateKey`:
+///
+/// > For X25519 and X448, private keys are identical to their byte string representation,
+/// > so little processing has to be done. The SerializePrivateKey() function MUST clamp its output
+///
+/// [RFC9810 §7.1.2]: https://datatracker.ietf.org/doc/html/rfc9180#section-7.1.2
+impl KeyExport for X25519DecapsulationKey {
+    fn to_bytes(&self) -> Key<Self> {
+        self.dk.to_bytes().into()
+    }
+}
+
+impl Generate for X25519DecapsulationKey {
+    fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        let key = Key::<Self>::try_generate_from_rng(rng)?;
+        Ok(StaticSecret::from(key.0).into())
+    }
+}
+
+impl Decapsulate<X25519Kem> for X25519DecapsulationKey {
+    fn decapsulate(&self, encapsulated_key: &Ciphertext) -> SharedKey {
+        let public_key = PublicKey::from(encapsulated_key.0);
+        self.dk.diffie_hellman(&public_key).to_bytes().into()
+    }
+}
+
+/// Elliptic Curve Diffie-Hellman Encapsulation Key (i.e. public encryption key)
+///
+/// Generic around an elliptic curve `C`.
+pub type X25519EncapsulationKey = EncapsulationKey<PublicKey>;
 
 /// From [RFC9810 §7.1.1]: `SerializePublicKey` and `DeserializePublicKey`:
 ///
@@ -72,31 +116,15 @@ impl KeyExport for X25519EncapsulationKey {
     }
 }
 
-impl Generate for X25519DecapsulationKey {
-    fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        // TODO(tarcieri): don't panic! Fallible `ReusableSecret` generation?
-        Ok(Self::from(ReusableSecret::random_from_rng(&mut UnwrapErr(
-            rng,
-        ))))
-    }
-}
-
 impl Encapsulate<X25519Kem> for X25519EncapsulationKey {
     fn encapsulate_with_rng<R>(&self, rng: &mut R) -> (Ciphertext, SharedKey)
     where
         R: CryptoRng + ?Sized,
     {
         // ECDH encapsulation involves creating a new ephemeral key pair and then doing DH
-        let sk = ReusableSecret::random_from_rng(rng);
+        let sk = StaticSecret::random_from_rng(rng);
         let pk = PublicKey::from(&sk);
         let ss = sk.diffie_hellman(&self.0);
         (pk.to_bytes().into(), ss.to_bytes().into())
-    }
-}
-
-impl Decapsulate<X25519Kem> for X25519DecapsulationKey {
-    fn decapsulate(&self, encapsulated_key: &Ciphertext) -> SharedKey {
-        let public_key = PublicKey::from(encapsulated_key.0);
-        self.dk.diffie_hellman(&public_key).to_bytes().into()
     }
 }

--- a/dhkem/tests/hpke_p256_test.rs
+++ b/dhkem/tests/hpke_p256_test.rs
@@ -2,10 +2,9 @@
 
 use core::convert::Infallible;
 use dhkem::NistP256DecapsulationKey;
-use elliptic_curve::Generate;
 use hex_literal::hex;
 use hkdf::Hkdf;
-use kem::{Encapsulate, KeyExport, TryDecapsulate};
+use kem::{Encapsulate, KeyExport, TryDecapsulate, TryKeyInit};
 use rand_core::{TryCryptoRng, TryRng};
 use sha2::Sha256;
 
@@ -68,6 +67,7 @@ fn extract_and_expand(shared_secret: &[u8], kem_context: &[u8]) -> Vec<u8> {
 #[test]
 // section A.3.1 https://datatracker.ietf.org/doc/html/rfc9180#appendix-A.3.1
 fn test_dhkem_p256_hkdf_sha256() {
+    let example_key = hex!("f3ce7fdae57e1a310d87f1ebbde6f328be0a99cdbcadf4d6589cf29de4b8ffd2");
     let example_pke = hex!(
         "04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b32\
          5ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4"
@@ -79,10 +79,7 @@ fn test_dhkem_p256_hkdf_sha256() {
     let example_shared_secret =
         hex!("c0d26aeab536609a572b07695d933b589dcf363ff9d93c93adea537aeabb8cb8");
 
-    let skr = NistP256DecapsulationKey::try_generate_from_rng(&mut ConstantRng(&hex!(
-        "f3ce7fdae57e1a310d87f1ebbde6f328be0a99cdbcadf4d6589cf29de4b8ffd2"
-    )))
-    .unwrap();
+    let skr = NistP256DecapsulationKey::new(&example_key.into()).unwrap();
     let pkr = skr.as_ref();
     assert_eq!(&pkr.to_bytes(), &example_pkr);
 


### PR DESCRIPTION
Support for importing and exporting such keys is part of the HPKE spec, which it calls `SerializePrivateKey` and `DeserializePrivateKey`.

This changes the inner types of `EcdhDecapsulationKey` and `X25519DecapsulationKey` to `elliptic_curve::SecretKey` and `x25519_dalek::StaticSecret` respectively, and impls the traits appropriate to the descriptions in RFC9810 §7.1.2:

- `EcdhDecapsulationKey` impls `TryKeyInit` because it MUST reject non-canonical (unreduced) scalar representatives
- `X25519DecapsulationKey` supports infallible `KeyInit` via clamping

Both are able to implement `KeyExport` using their respective serialization formats.

This required some changes to `elliptic-curve` since there were gaps in the `SecretKey`/`PublicKey` types, so a temporary git dependency has been added.