### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "dhkem"
-version = "0.1.0-pre.2"
+version = "0.1.0-pre.3"
 dependencies = [
  "elliptic-curve",
  "getrandom",
@@ -402,8 +402,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.24"
-source = "git+https://github.com/RustCrypto/traits#43d020754c46cd81ca8d13c980f48215aa362627"
+version = "0.14.0-rc.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e41550a307f4f1b2d52dae190683f7f4c4610ec29006acf0a906c26e81c4ac"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -766,7 +767,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "ml-kem"
-version = "0.3.0-pre.5"
+version = "0.3.0-pre.6"
 dependencies = [
  "const-oid",
  "criterion",
@@ -1732,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "x-wing"
-version = "0.1.0-pre.5"
+version = "0.1.0-pre.6"
 dependencies = [
  "getrandom",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,3 @@ debug = true
 [patch.crates-io]
 ml-kem = { path = "./ml-kem" }
 module-lattice = { path = "./module-lattice" }
-
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of Key Encapsulation Mechanism (KEM) adapters for Elliptic Curve
 Diffie Hellman (ECDH) protocols
 """
-version = "0.1.0-pre.2"
+version = "0.1.0-pre.3"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -18,7 +18,7 @@ kem = "0.3.0-rc.3"
 rand_core = "0.10.0-rc-6"
 
 # optional dependencies
-elliptic-curve = { version = "0.14.0-rc.24", optional = true, default-features = false }
+elliptic-curve = { version = "0.14.0-rc.25", optional = true, default-features = false }
 k256 = { version = "0.14.0-rc.6", optional = true, default-features = false, features = ["arithmetic"] }
 p256 = { version = "0.14.0-rc.6", optional = true, default-features = false, features = ["arithmetic"] }
 p384 = { version = "0.14.0-rc.6", optional = true, default-features = false, features = ["arithmetic"] }

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Module-Lattice-Based Key-Encapsulation Mechanism Standard
 (formerly known as Kyber) as described in FIPS 203
 """
-version = "0.3.0-pre.5"
+version = "0.3.0-pre.6"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -29,7 +29,7 @@ array = { version = "0.4.4", package = "hybrid-array", features = ["extra-sizes"
 module-lattice = { version = "0.1.0-rc.0", features = ["subtle"] }
 kem = "0.3.0-rc.3"
 rand_core = "0.10.0-rc-6"
-sha3 = { version = "0.11.0-rc.3", default-features = false }
+sha3 = { version = "0.11.0-rc.6", default-features = false }
 subtle = { version = "2", default-features = false }
 
 # optional dependencies

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "x-wing"
 description = "Pure Rust implementation of the X-Wing Key Encapsulation Mechanism (draft 06)"
-version = "0.1.0-pre.5"
+version = "0.1.0-pre.6"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -20,9 +20,9 @@ hazmat = []
 
 [dependencies]
 kem = "0.3.0-rc.3"
-ml-kem = { version = "=0.3.0-pre.5", default-features = false, features = ["hazmat"] }
+ml-kem = { version = "=0.3.0-pre.6", default-features = false, features = ["hazmat"] }
 rand_core = { version = "0.10.0-rc-6", default-features = false }
-sha3 = { version = "0.11.0-rc.4", default-features = false }
+sha3 = { version = "0.11.0-rc.6", default-features = false }
 x25519-dalek = { version = "=3.0.0-pre.5", default-features = false, features = ["static_secrets"] }
 
 # optional dependencies


### PR DESCRIPTION
Releases the following with support for the new `kem` v0.3.0-rc.3 API:
- `dhkem` v0.1.0-pre.3
- `ml-kem` v0.3.0-pre.6
- `x-wing` v0.1.0-pre.6