### PR TITLE
ml-kem: add `reason` to all `clippy` div/rem `allow`s

### DIFF
--- a/ml-kem/src/algebra.rs
+++ b/ml-kem/src/algebra.rs
@@ -264,10 +264,10 @@ fn base_case_multiply(a0: Elem, a1: Elem, b0: Elem, b1: Elem, i: usize) -> (Elem
 ///
 /// The values computed here match those provided in Appendix A of FIPS 203.
 /// `ZETA_POW_BITREV` corresponds to the first table, and `GAMMA` to the second table.
-#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::integer_division_remainder_used, reason = "constant")]
 const ZETA_POW_BITREV: [Elem; 128] = {
     const ZETA: u64 = 17;
-    #[allow(clippy::integer_division_remainder_used)]
+
     const fn bitrev7(x: usize) -> usize {
         ((x >> 6) % 2)
             | (((x >> 5) % 2) << 1)
@@ -282,9 +282,9 @@ const ZETA_POW_BITREV: [Elem; 128] = {
     let mut pow = [Elem::new(0); 128];
     let mut i = 0;
     let mut curr = 1u64;
-    #[allow(clippy::integer_division_remainder_used)]
+
     while i < 128 {
-        pow[i] = Elem::new(curr as u16);
+        pow[i] = Elem::new((curr & 0xFFFF) as u16);
         i += 1;
         curr = (curr * ZETA) % BaseField::QLL;
     }
@@ -299,16 +299,15 @@ const ZETA_POW_BITREV: [Elem; 128] = {
     pow_bitrev
 };
 
-#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::integer_division_remainder_used, reason = "constant")]
 const GAMMA: [Elem; 128] = {
     const ZETA: u64 = 17;
     let mut gamma = [Elem::new(0); 128];
     let mut i = 0;
     while i < 128 {
         let zpr = ZETA_POW_BITREV[i].0 as u64;
-        #[allow(clippy::integer_division_remainder_used)]
         let g = (zpr * zpr * ZETA) % BaseField::QLL;
-        gamma[i] = Elem::new(g as u16);
+        gamma[i] = Elem::new((g & 0xFFFF) as u16);
         i += 1;
     }
     gamma

--- a/ml-kem/src/compress.rs
+++ b/ml-kem/src/compress.rs
@@ -17,7 +17,7 @@ where
     const POW2_HALF: u32 = 1 << (T::USIZE - 1);
     const MASK: Int = ((1 as Int) << T::USIZE) - 1;
     const DIV_SHIFT: usize = 34;
-    #[allow(clippy::integer_division_remainder_used)]
+    #[allow(clippy::integer_division_remainder_used, reason = "constant")]
     const DIV_MUL: u64 = (1 << T::DIV_SHIFT) / BaseField::QLL;
 }
 
@@ -87,25 +87,24 @@ impl<K: ArraySize> Compress for Vector<K> {
 }
 
 #[cfg(test)]
-pub(crate) mod test {
+#[allow(clippy::cast_possible_truncation, reason = "tests")]
+#[allow(clippy::integer_division_remainder_used, reason = "tests")]
+pub(crate) mod tests {
     use super::*;
     use array::typenum::{U1, U4, U5, U6, U10, U11, U12};
     use num_rational::Ratio;
 
-    #[allow(clippy::cast_possible_truncation)]
     fn rational_compress<D: CompressionFactor>(input: u16) -> u16 {
         let fraction = Ratio::new(u32::from(input) * (1 << D::USIZE), BaseField::QL);
         (fraction.round().to_integer() as u16) & D::MASK
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn rational_decompress<D: CompressionFactor>(input: u16) -> u16 {
         let fraction = Ratio::new(u32::from(input) * BaseField::QL, 1 << D::USIZE);
         fraction.round().to_integer() as u16
     }
 
     // Verify against inequality 4.7
-    #[allow(clippy::integer_division_remainder_used)]
     fn compression_decompression_inequality<D: CompressionFactor>() {
         const QI32: i32 = BaseField::Q as i32;
         let error_threshold = i32::from(Ratio::new(BaseField::Q, 1 << D::USIZE).to_integer());


### PR DESCRIPTION
For allow instances of `allow(clippy::integer_division_remainder_used)` adds a `reason` field which is now one of "constant" (as in bound to an all-caps-named `const` value) or "tests".