### PR TITLE
dhkem: enable and fix lints

### DIFF
--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -44,6 +44,9 @@ p521 = ["dep:p521", "ecdh"]
 x25519 = ["dep:x25519", "x25519/static_secrets"]
 zeroize = ["dep:zeroize"]
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/dhkem/src/lib.rs
+++ b/dhkem/src/lib.rs
@@ -127,7 +127,7 @@ where
 #[cfg(feature = "zeroize")]
 impl<DK: Zeroize, EK> Zeroize for DecapsulationKey<DK, EK> {
     fn zeroize(&mut self) {
-        self.dk.zeroize()
+        self.dk.zeroize();
     }
 }
 

--- a/dhkem/tests/hpke_p256_test.rs
+++ b/dhkem/tests/hpke_p256_test.rs
@@ -1,4 +1,8 @@
+//! HPKE tests (P-256 only)
+
 #![cfg(feature = "p256")]
+#![allow(clippy::unwrap_in_result, reason = "tests")]
+#![allow(clippy::unwrap_used, reason = "tests")]
 
 use core::convert::Infallible;
 use dhkem::NistP256DecapsulationKey;

--- a/dhkem/tests/tests.rs
+++ b/dhkem/tests/tests.rs
@@ -1,3 +1,5 @@
+//! DHKEM tests.
+
 #![cfg(any(
     feature = "k256",
     feature = "p256",
@@ -5,6 +7,7 @@
     feature = "p521",
     feature = "x25519"
 ))]
+#![allow(clippy::unwrap_used, reason = "tests")]
 
 use kem::{Encapsulate, Generate, Kem, TryDecapsulate};
 


### PR DESCRIPTION
Enables the workspace-level lint config added in #232