### PR TITLE
dhkem: add `Expander`

### DIFF
--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["crypto", "ecdh", "ecc"]
 readme = "README.md"
 
 [dependencies]
+hkdf = "0.13.0-rc.4"
 kem = "0.3.0-rc.3"
 rand_core = "0.10.0-rc-6"
 

--- a/dhkem/src/ecdh_kem.rs
+++ b/dhkem/src/ecdh_kem.rs
@@ -15,6 +15,9 @@ use kem::{
 };
 use rand_core::{CryptoRng, TryCryptoRng};
 
+#[cfg(doc)]
+use crate::Expander;
+
 /// Generic Elliptic Curve Diffie-Hellman KEM adapter compatible with curves implemented using
 /// traits from the `elliptic-curve` crate.
 ///
@@ -93,6 +96,15 @@ where
     }
 }
 
+/// <div class="warning">
+/// <b><code>SharedKey</code> is non-uniform raw ECDH output!</b>
+///
+/// The resulting [`SharedKey`] is the non-uniform raw output of the Elliptic Curve Diffie-Hellman
+/// operation (i.e. coordinate of an elliptic curve point).
+///
+/// To produce something suitable for e.g. symmetric key(s), use the [`Expander`] type to derive
+/// output keys.
+/// </div>
 impl<C> TryDecapsulate<EcdhKem<C>> for EcdhDecapsulationKey<C>
 where
     C: CurveArithmetic,
@@ -170,6 +182,15 @@ where
     }
 }
 
+/// <div class="warning">
+/// <b><code>SharedKey</code> is non-uniform raw ECDH output!</b>
+///
+/// The resulting [`SharedKey`] is the non-uniform raw output of the Elliptic Curve Diffie-Hellman
+/// operation (i.e. coordinate of an elliptic curve point).
+///
+/// To produce something suitable for e.g. symmetric key(s), use the [`Expander`] type to derive
+/// output keys.
+/// </div>
 impl<C> Encapsulate<EcdhKem<C>> for EcdhEncapsulationKey<C>
 where
     C: CurveArithmetic,

--- a/dhkem/src/expander.rs
+++ b/dhkem/src/expander.rs
@@ -1,0 +1,159 @@
+pub use hkdf::InvalidLength;
+
+use core::iter;
+use hkdf::{Hkdf, hmac::digest::block_api::EagerHash};
+
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
+/// Maximum size of the concatenated prefixes when performing labeled operations.
+const PREFIXES_MAX: usize = 256;
+
+/// Maximum size of input key material or info after applying prefixes.
+const LABELED_INPUT_MAX: usize = PREFIXES_MAX + 64;
+
+/// HPKE version identifier from `RFC9810 §4`.
+const HPKE_VERSION_ID: &[u8] = b"HPKE-v1";
+
+/// HPKE suite ID from `RFC9810 §4`.
+const HPKE_SUITE_ID: &[u8] = b"KEM\x00\x10";
+
+/// Expander: wrapper for [RFC5869] HKDF-Expand operation which can be used for HPKE's
+/// `LabeledExtract` and `LabeledExpand` as described in [RFC9810 §4].
+///
+/// [RFC5869]: https://datatracker.ietf.org/doc/html/rfc5869
+/// [RFC9810 §4]: https://datatracker.ietf.org/doc/html/rfc9180#section-4
+#[derive(Debug)]
+pub struct Expander<D: EagerHash> {
+    /// Inner HKDF instance
+    hkdf: Hkdf<D>,
+}
+
+impl<D: EagerHash> Expander<D> {
+    /// Create a new expander with the given salt and input key material.
+    #[must_use]
+    pub fn new(salt: &[u8], input_key_material: &[u8]) -> Self {
+        Self {
+            hkdf: Hkdf::<D>::new(Some(salt), input_key_material),
+        }
+    }
+
+    /// Create a new expander with a slice of prefixes concatenated to the IKM.
+    ///
+    /// # Errors
+    /// Returns [`InvalidLength`] if the concatenated prefixes are too long.
+    pub fn new_prefixed(
+        salt: &[u8],
+        prefixes: &[&[u8]],
+        input_key_material: &[u8],
+    ) -> Result<Self, InvalidLength> {
+        let mut labeled_ikm_buf = [0u8; LABELED_INPUT_MAX];
+        let labeled_ikm = concat_slices(
+            prefixes
+                .iter()
+                .copied()
+                .chain(iter::once(input_key_material)),
+            &mut labeled_ikm_buf,
+        )?;
+
+        let ret = Self::new(salt, labeled_ikm);
+
+        #[cfg(feature = "zeroize")]
+        labeled_ikm_buf.zeroize();
+
+        Ok(ret)
+    }
+
+    /// Create a new expander which uses the prefixes that implement HPKE `LabeledExtract` as
+    /// described in [RFC9810 §4].
+    ///
+    /// # Errors
+    /// Returns [`InvalidLength`] if the concatenated prefixes are too long.
+    ///
+    /// [RFC9810 §4]: https://datatracker.ietf.org/doc/html/rfc9180#section-4
+    pub fn new_labeled_hpke(
+        salt: &[u8],
+        label: &[u8],
+        input_key_material: &[u8],
+    ) -> Result<Self, InvalidLength> {
+        Self::new_prefixed(
+            salt,
+            &[HPKE_VERSION_ID, HPKE_SUITE_ID, label],
+            input_key_material,
+        )
+    }
+
+    /// Perform the [RFC5869] `HKDF-Expand` operation, generating uniformly random output key
+    /// material that fills `okm` in its entirety.
+    ///
+    /// If you don’t have any info to pass, use an empty slice.
+    ///
+    /// # Errors
+    /// Returns [`InvalidLength`] if info is too long.
+    ///
+    /// [RFC5869]: https://datatracker.ietf.org/doc/html/rfc5869
+    /// [RFC9810 §4]: https://datatracker.ietf.org/doc/html/rfc9180#section-4
+    pub fn expand(&self, info: &[u8], okm: &mut [u8]) -> Result<(), InvalidLength> {
+        self.hkdf.expand(info, okm)
+    }
+
+    /// Performs the [RFC5869] `HKDF-Expand` operation with `info` assembled from a slice-of-slices.
+    ///
+    /// This is equivalent to calling `expand` with the `info` argument set equal to the
+    /// concatenation of all the elements of `info_components`.
+    ///
+    /// # Errors
+    /// Returns [`InvalidLength`] if info is too long.
+    ///
+    /// [RFC5869]: https://datatracker.ietf.org/doc/html/rfc5869
+    pub fn expand_multi_info(
+        &self,
+        info_components: &[&[u8]],
+        okm: &mut [u8],
+    ) -> Result<(), InvalidLength> {
+        self.hkdf.expand_multi_info(info_components, okm)
+    }
+
+    /// Create a new expander which uses the prefixes that implement HPKE `LabeledExpand` as
+    /// described in [RFC9810 §4].
+    ///
+    /// # Errors
+    /// Returns [`InvalidLength`] if label and/or info is too long.
+    ///
+    /// [RFC9810 §4]: https://datatracker.ietf.org/doc/html/rfc9180#section-4
+    pub fn expand_labeled_hpke(
+        &self,
+        label: &[u8],
+        info: &[u8],
+        okm: &mut [u8],
+    ) -> Result<(), InvalidLength> {
+        let okm_len = u16::try_from(okm.len()).map_err(|_| InvalidLength)?;
+        self.hkdf.expand_multi_info(
+            &[
+                &okm_len.to_be_bytes(),
+                HPKE_VERSION_ID,
+                HPKE_SUITE_ID,
+                label,
+                info,
+            ],
+            okm,
+        )
+    }
+}
+
+fn concat_slices<'a, I>(slices: I, out: &mut [u8]) -> Result<&[u8], InvalidLength>
+where
+    I: Iterator<Item = &'a [u8]>,
+{
+    let mut offset = 0usize;
+    for segment in slices {
+        let new_offset = offset.checked_add(segment.len()).ok_or(InvalidLength)?;
+        out.get_mut(offset..new_offset)
+            .ok_or(InvalidLength)?
+            .copy_from_slice(segment);
+
+        offset = new_offset;
+    }
+
+    Ok(&out[..offset])
+}

--- a/dhkem/src/lib.rs
+++ b/dhkem/src/lib.rs
@@ -29,6 +29,9 @@
 //! [RFC9180]: https://datatracker.ietf.org/doc/html/rfc9180#name-dh-based-kem-dhkem
 //! [TLS KEM combiner]: https://datatracker.ietf.org/doc/html/draft-ietf-tls-hybrid-design-10
 
+mod expander;
+
+pub use expander::{Expander, InvalidLength};
 pub use kem::{self, Encapsulate, Generate, Kem, TryDecapsulate};
 
 #[cfg(feature = "ecdh")]
@@ -86,16 +89,16 @@ impl<DK, EK> DecapsulationKey<DK, EK> {
 #[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Default)]
 pub struct EncapsulationKey<EK>(EK);
 
-impl<EK> From<EK> for EncapsulationKey<EK> {
-    fn from(inner: EK) -> Self {
-        Self(inner)
+impl<EK> EncapsulationKey<EK> {
+    /// Consumes `self` and returns the wrapped value
+    pub fn into_inner(self) -> EK {
+        self.0
     }
 }
 
-impl<X> EncapsulationKey<X> {
-    /// Consumes `self` and returns the wrapped value
-    pub fn into_inner(self) -> X {
-        self.0
+impl<EK> From<EK> for EncapsulationKey<EK> {
+    fn from(inner: EK) -> Self {
+        Self(inner)
     }
 }
 

--- a/dhkem/src/x25519_kem.rs
+++ b/dhkem/src/x25519_kem.rs
@@ -7,6 +7,9 @@ use kem::{
 use rand_core::{CryptoRng, TryCryptoRng};
 use x25519::{PublicKey, StaticSecret};
 
+#[cfg(doc)]
+use crate::Expander;
+
 /// X25519 ciphertexts are compressed Montgomery x/u-coordinates.
 type Ciphertext = Array<u8, U32>;
 
@@ -67,6 +70,15 @@ impl Generate for X25519DecapsulationKey {
     }
 }
 
+/// <div class="warning">
+/// <b><code>SharedKey</code> is non-uniform raw ECDH output!</b>
+///
+/// The resulting `SharedKey` is the non-uniform raw output of the Elliptic Curve Diffie-Hellman
+/// operation (i.e. coordinate of an elliptic curve point).
+///
+/// To produce something suitable for e.g. symmetric key(s), use the [`Expander`] type to derive
+/// output keys.
+/// </div>
 impl Decapsulate<X25519Kem> for X25519DecapsulationKey {
     fn decapsulate(&self, encapsulated_key: &Ciphertext) -> SharedKey {
         let public_key = PublicKey::from(encapsulated_key.0);
@@ -116,6 +128,15 @@ impl KeyExport for X25519EncapsulationKey {
     }
 }
 
+/// <div class="warning">
+/// <b><code>SharedKey</code> is non-uniform raw ECDH output!</b>
+///
+/// The resulting `SharedKey` is the non-uniform raw output of the Elliptic Curve Diffie-Hellman
+/// operation (i.e. coordinate of an elliptic curve point).
+///
+/// To produce something suitable for e.g. symmetric key(s), use the [`Expander`] type to derive
+/// output keys.
+/// </div>
 impl Encapsulate<X25519Kem> for X25519EncapsulationKey {
     fn encapsulate_with_rng<R>(&self, rng: &mut R) -> (Ciphertext, SharedKey)
     where


### PR DESCRIPTION
The `dhkem` crate is implemented so its output is the raw x-coordinate of the shared curve point resulting from ECDH. Such a coordinate is non-uniform.

A subsequent derivation step must be applied to have output suitable for use as key material. However, the exact nature of that derivation is algorithm-specific.

This provides a wrapper type for HKDF which implements either generic HKDF support or support for the "labeled" operations from HPKE.

The `Encapsulate` and `(Try)Decapsulate` impls now warn that the output is non-uniform and suggest using `Expander`.