### PR TITLE
module-lattice: flatten API

### DIFF
--- a/ml-kem/src/algebra.rs
+++ b/ml-kem/src/algebra.rs
@@ -1,37 +1,34 @@
-use array::{Array, typenum::U256};
-use module_lattice::{
-    algebra::{Field, MultiplyNtt},
-    encoding::Encode,
-    truncate::Truncate,
+use crate::{
+    B32,
+    crypto::{PRF, PrfOutput, XOF},
+    param::CbdSamplingSize,
 };
+use array::{Array, ArraySize, typenum::U256};
+use module_lattice::{Encode, Field, MultiplyNtt, Truncate};
 use sha3::digest::XofReader;
-
-use crate::B32;
-use crate::crypto::{PRF, PrfOutput, XOF};
-use crate::param::{ArraySize, CbdSamplingSize};
 
 module_lattice::define_field!(BaseField, u16, u32, u64, 3329);
 
 pub(crate) type Int = <BaseField as Field>::Int;
 
 /// An element of GF(q).
-pub(crate) type Elem = module_lattice::algebra::Elem<BaseField>;
+pub(crate) type Elem = module_lattice::Elem<BaseField>;
 
 /// An element of the ring `R_q`, i.e., a polynomial over `Z_q` of degree 255
-pub(crate) type Polynomial = module_lattice::algebra::Polynomial<BaseField>;
+pub(crate) type Polynomial = module_lattice::Polynomial<BaseField>;
 
 /// A vector of polynomials of length `K`.
-pub(crate) type Vector<K> = module_lattice::algebra::Vector<BaseField, K>;
+pub(crate) type Vector<K> = module_lattice::Vector<BaseField, K>;
 
 /// An element of the ring `T_q` i.e. a tuple of 128 elements of the direct sum components of `T_q`.
-pub(crate) type NttPolynomial = module_lattice::algebra::NttPolynomial<BaseField>;
+pub(crate) type NttPolynomial = module_lattice::NttPolynomial<BaseField>;
 
 /// A vector of K NTT-domain polynomials.
-pub(crate) type NttVector<K> = module_lattice::algebra::NttVector<BaseField, K>;
+pub(crate) type NttVector<K> = module_lattice::NttVector<BaseField, K>;
 
 /// A K x K matrix of NTT-domain polynomials.  Each vector represents a row of the matrix, so that
 /// multiplying on the right just requires iteration.
-pub(crate) type NttMatrix<K> = module_lattice::algebra::NttMatrix<BaseField, K, K>;
+pub(crate) type NttMatrix<K> = module_lattice::NttMatrix<BaseField, K, K>;
 
 /// Algorithm 7: `SampleNTT(B)`
 pub(crate) fn sample_ntt(B: &mut impl XofReader) -> NttPolynomial {
@@ -316,11 +313,11 @@ const GAMMA: [Elem; 128] = {
 #[cfg(test)]
 mod test {
     use super::{
-        Array, ArraySize, B32, BaseField, Elem, Field, Int, Ntt, NttInverse, NttMatrix,
-        NttPolynomial, NttVector, PRF, Polynomial, U256, XOF,
+        Array, B32, BaseField, Elem, Field, Int, Ntt, NttInverse, NttMatrix, NttPolynomial,
+        NttVector, PRF, Polynomial, U256, XOF,
     };
     use array::{
-        Flatten,
+        ArraySize, Flatten,
         typenum::{U2, U3, U8},
     };
 

--- a/ml-kem/src/compress.rs
+++ b/ml-kem/src/compress.rs
@@ -1,6 +1,7 @@
 use crate::algebra::{BaseField, Elem, Int, Polynomial, Vector};
-use crate::param::{ArraySize, EncodingSize};
-use module_lattice::{algebra::Field, truncate::Truncate};
+use array::ArraySize;
+use module_lattice::EncodingSize;
+use module_lattice::{Field, Truncate};
 
 // A convenience trait to allow us to associate some constants with a typenum
 pub(crate) trait CompressionFactor: EncodingSize {

--- a/ml-kem/src/crypto.rs
+++ b/ml-kem/src/crypto.rs
@@ -1,13 +1,10 @@
 #![allow(dead_code)]
 
+use crate::{B32, param::CbdSamplingSize};
+use module_lattice::EncodedPolynomial;
 use sha3::{
     Digest, Sha3_256, Sha3_512, Shake128, Shake256,
     digest::{ExtendableOutput, Update, XofReader},
-};
-
-use crate::{
-    B32,
-    param::{CbdSamplingSize, EncodedPolynomial},
 };
 
 pub(crate) fn G(inputs: &[impl AsRef<[u8]>]) -> (B32, B32) {

--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -68,7 +68,7 @@ mod param;
 // PKCS#8 key encoding support (doc comments in module)
 pub mod pkcs8;
 
-pub use array;
+pub use array::{self, ArraySize};
 #[allow(deprecated)]
 pub use decapsulation_key::ExpandedKeyEncoding;
 pub use decapsulation_key::{DecapsulationKey, FromSeed};
@@ -80,7 +80,6 @@ pub use kem::{
 pub use ml_kem_512::MlKem512;
 pub use ml_kem_768::MlKem768;
 pub use ml_kem_1024::MlKem1024;
-pub use module_lattice::encoding::ArraySize;
 pub use param::{ExpandedDecapsulationKey, ParameterSet};
 
 use array::{

--- a/ml-kem/src/param.rs
+++ b/ml-kem/src/param.rs
@@ -10,11 +10,6 @@
 //! know any details about object sizes.  For example, `VectorEncodingSize::flatten` needs to know
 //! that the size of an encoded vector is `K` times the size of an encoded polynomial.
 
-pub(crate) use module_lattice::encoding::{
-    ArraySize, Encode, EncodedPolynomial, EncodedPolynomialSize, EncodedVectorSize, EncodingSize,
-    VectorEncodingSize,
-};
-
 use crate::{
     B32, Ciphertext, Kem,
     algebra::{BaseField, Elem, NttVector},
@@ -30,7 +25,10 @@ use core::{
     fmt::Debug,
     ops::{Add, Div, Mul, Rem, Sub},
 };
-use module_lattice::algebra::Field;
+use module_lattice::{
+    ArraySize, Encode, EncodedPolynomialSize, EncodedVectorSize, EncodingSize, Field,
+    VectorEncodingSize,
+};
 
 #[cfg(doc)]
 use crate::Seed;

--- a/ml-kem/src/pke.rs
+++ b/ml-kem/src/pke.rs
@@ -8,7 +8,7 @@ use crate::crypto::{G, PRF};
 use crate::param::{EncodedDecryptionKey, EncodedEncryptionKey, PkeParams};
 use array::typenum::{U1, Unsigned};
 use kem::{Ciphertext, InvalidKey};
-use module_lattice::encoding::Encode;
+use module_lattice::Encode;
 use subtle::{Choice, ConstantTimeEq};
 
 #[cfg(feature = "zeroize")]

--- a/module-lattice/src/algebra.rs
+++ b/module-lattice/src/algebra.rs
@@ -57,7 +57,7 @@ macro_rules! define_field {
         #[derive(Copy, Clone, Default, Debug, Eq, PartialEq)]
         pub struct $field;
 
-        impl $crate::algebra::Field for $field {
+        impl $crate::Field for $field {
             type Int = $int;
             type Long = $long;
             type LongLong = $longlong;
@@ -80,7 +80,7 @@ macro_rules! define_field {
                 let product = x * Self::BARRETT_MULTIPLIER;
                 let quotient = product >> Self::BARRETT_SHIFT;
                 let remainder = x - quotient * Self::QLL;
-                Self::small_reduce($crate::truncate::Truncate::truncate(remainder))
+                Self::small_reduce($crate::Truncate::truncate(remainder))
             }
         }
     };

--- a/module-lattice/src/lib.rs
+++ b/module-lattice/src/lib.rs
@@ -11,11 +11,20 @@
 
 /// Linear algebra with degree-256 polynomials over a prime-order field, vectors of such
 /// polynomials, and NTT polynomials / vectors
-pub mod algebra;
+mod algebra;
 
 /// Packing of polynomials into coefficients with a specified number of bits.
-pub mod encoding;
+mod encoding;
 
 /// Utility functions such as truncating integers, flattening arrays of arrays, and unflattening
 /// arrays into arrays of arrays.
-pub mod truncate;
+mod truncate;
+
+pub use algebra::{
+    Elem, Field, MultiplyNtt, NttMatrix, NttPolynomial, NttVector, Polynomial, Vector,
+};
+pub use encoding::{
+    ArraySize, DecodedValue, Encode, EncodedPolynomial, EncodedPolynomialSize, EncodedVector,
+    EncodedVectorSize, EncodingSize, VectorEncodingSize, byte_decode, byte_encode,
+};
+pub use truncate::Truncate;

--- a/module-lattice/tests/algebra.rs
+++ b/module-lattice/tests/algebra.rs
@@ -4,9 +4,7 @@
 #![allow(clippy::integer_division_remainder_used, reason = "tests")]
 
 use array::typenum::U2;
-use module_lattice::algebra::{
-    Elem, Field, NttMatrix, NttPolynomial, NttVector, Polynomial, Vector,
-};
+use module_lattice::{Elem, Field, NttMatrix, NttPolynomial, NttVector, Polynomial, Vector};
 
 // Field used by ML-KEM.
 module_lattice::define_field!(KyberField, u16, u32, u64, 3329);

--- a/module-lattice/tests/encode.rs
+++ b/module-lattice/tests/encode.rs
@@ -3,28 +3,26 @@
 #![allow(clippy::cast_possible_truncation, reason = "tests")]
 #![allow(clippy::integer_division_remainder_used, reason = "tests")]
 
-use array::sizes::U3;
-use array::typenum::{Mod, Zero};
 use array::{
-    Array,
-    sizes::{U1, U2, U4, U5, U6, U8, U10, U11, U12, U256},
+    Array, ArraySize,
+    sizes::{U1, U2, U3, U4, U5, U6, U8, U10, U11, U12, U256},
+    typenum::{Mod, Zero},
 };
 use core::{fmt::Debug, ops::Rem};
 use getrandom::{
     SysRng,
     rand_core::{Rng, UnwrapErr},
 };
-use module_lattice::encoding::EncodedVector;
 use module_lattice::{
-    algebra::{Elem, Field, NttPolynomial, NttVector, Polynomial, Vector},
-    encoding::{ArraySize, Encode, EncodedPolynomial, EncodingSize, byte_decode, byte_encode},
+    Elem, Encode, EncodedPolynomial, EncodedVector, EncodingSize, Field, NttPolynomial, NttVector,
+    Polynomial, Vector, byte_decode, byte_encode,
 };
 
 // Field used by ML-KEM.
 module_lattice::define_field!(KyberField, u16, u32, u64, 3329);
 
 type Int = u16;
-type DecodedValue = module_lattice::encoding::DecodedValue<KyberField>;
+type DecodedValue = module_lattice::DecodedValue<KyberField>;
 
 /// A helper trait to construct larger arrays by repeating smaller ones
 trait Repeat<T: Clone, D: ArraySize> {


### PR DESCRIPTION
Removes the modules from the public API, instead re-exporting everything at the toplevel.

The functionality nicely groups itself by the items being re-exported: the algebra functionality is structs (and a couple traits), where the encoding functionality is all type aliases and traits, most of which start with `Encode*`.