### PR TITLE
Bump dependency requirements in `Cargo.toml`(s)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,12 +4,12 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9e1c818b25efb32214df89b0ec22f01aa397aaeb718d1022bf0635a3bfd1a8"
+checksum = "04097e08a47d9ad181c2e1f4a5fabc9ae06ce8839a333ba9a949bcb0d31fd2a3"
 dependencies = [
- "cfg-if",
  "cipher",
+ "cpubits",
  "cpufeatures",
 ]
 
@@ -118,9 +118,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.9"
+version = "0.10.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c81d916c6ae06736ec667b51f95ee5ff660a75f4ea6ce1bd932c942365c0ea43"
+checksum = "c536927023d1c432e6e23a25ef45f6756094eac2ab460db5fb17a772acdfd312"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.5"
+version = "0.5.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557bad79bc426785757001b5d732f323ae965363983d758295c1a1935496880"
+checksum = "9002c8edb9b1e21938663da3489c9c4403bba2393997fb2ecbd401386c0e71dc"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -211,6 +211,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
 
 [[package]]
 name = "cpufeatures"
@@ -293,10 +299,11 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.22"
+version = "0.7.0-rc.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c3561863ce55e3226ecc48b08679f4b66cb1b92b9afb42c2c402dfe8b9b51"
+checksum = "cba9eeeb213f7fd29353032f71f7c173e5f6d95d85151cb3a47197b0ea7e8be7"
 dependencies = [
+ "cpubits",
  "ctutils",
  "hybrid-array",
  "num-traits",
@@ -307,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
+checksum = "6f8441110cea75afde0b89a8d796e2bc67b23432f5a9566cb15d9d365d91a2b0"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -384,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.9"
+version = "0.11.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff8de092798697546237a3a701e4174fe021579faec9b854379af9bf1e31962"
+checksum = "02b42f1d9edf5207c137646b568a0168ca0ec25b7f9eaf7f9961da51a3d91cea"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -402,9 +409,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.25"
+version = "0.14.0-rc.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e41550a307f4f1b2d52dae190683f7f4c4610ec29006acf0a906c26e81c4ac"
+checksum = "bde7860544606d222fd6bd6d9f9a0773321bf78072a637e1d560a058c0031978"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -528,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.0-rc.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f70a332ddf75e5e5e43284304179ba02f391f82f692f030b08a8378adf3c99"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
  "libc",
@@ -624,18 +631,18 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hkdf"
-version = "0.13.0-rc.4"
+version = "0.13.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1493605868fc7d216afa78a26956d56f5c0a12dbdb8ee4fe9e0b70a28ec7d57"
+checksum = "cbb55385998ae66b8d2d5143c05c94b9025ab863966f0c94ce7a5fde30105092"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.4"
+version = "0.13.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9956e202a691c5c86c60303a421f66f93f44b29433407b7c43cf2bebadc750e"
+checksum = "ef451d73f36d8a3f93ad32c332ea01146c9650e1ec821a9b0e46c01277d544f8"
 dependencies = [
  "digest",
 ]
@@ -705,11 +712,11 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb5f9253d4a600323279707ab36a1f1a74d21e85a43f048cce0bfea2928c637"
+checksum = "83da23da11f0b5db6f23d9280a84b3a33a746aa43ebb9270d6b445991da9cee3"
 dependencies = [
- "cfg-if",
+ "cpubits",
  "elliptic-curve",
 ]
 
@@ -724,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "kem"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb982d00ac39162293481bac7f737b667d4ed1661bf057529466bf031351d43"
+checksum = "1c154411ffe1b199ef0b7e209e0cd2f05460aa5b9483873979042bfb02d0addd"
 dependencies = [
  "crypto-common",
  "rand_core",
@@ -863,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1286c2d38465adf5a7d970766796c1fb343172c58fd70f69e8d96e7d9dcbe4"
+checksum = "018bfbb86e05fd70a83e985921241035ee09fcd369c4a2c3680b389a01d2ad28"
 dependencies = [
  "elliptic-curve",
  "primefield",
@@ -874,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7574cab645ebcc13db3a531ae853d369e786270efd8b7fdb61de5c9328438d"
+checksum = "8c91df688211f5957dbe2ab599dcbcaade8d6d3cdc15c5b350d350d7d07ce423"
 dependencies = [
  "elliptic-curve",
  "fiat-crypto",
@@ -886,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa943740d30f154f6370223a510d5111d08528bf857cb61359048e61983b3eb0"
+checksum = "de6cd9451de522549d36cc78a1b45a699a3d55a872e8ea0c8f0318e502d99e2c"
 dependencies = [
  "base16ct",
  "elliptic-curve",
@@ -986,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d00b69a9bd66d09004e2db633068d5af00435f6e673838e50f2944b8033ec8"
+checksum = "93401c13cc7ff24684571cfca9d3cf9ebabfaf3d4b7b9963ade41ec54da196b5"
 dependencies = [
  "crypto-bigint",
  "crypto-common",
@@ -1000,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "156aeda78c4a7e86701563514573bc28f127eec880bfa6a22efc4b8139b1c049"
+checksum = "a0c5c8a39bcd764bfedf456e8d55e115fe86dda3e0f555371849f2a41cbc9706"
 dependencies = [
  "elliptic-curve",
 ]
@@ -1042,9 +1049,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70765ff7112b0fb2d272d24d9a2f907fc206211304328fe58b2db15a5649ef28"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rayon"
@@ -1141,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-ff"
-version = "0.14.0-pre.1"
+version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36fdf8f956089df8343b9479045c026932f9eb004d0f32d8497b4d133b316a66"
+checksum = "c5db129183b2c139d7d87d08be57cba626c715789db17aec65c8866bfd767d1f"
 dependencies = [
  "rand_core",
  "subtle",
@@ -1151,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-group"
-version = "0.14.0-pre.1"
+version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df76d08c12814c794ffe95ac788b48081cccb607fade4ed746825d29791ce538"
+checksum = "57c4b1463f274a3ff6fb2f44da43e576cb9424367bd96f185ead87b52fe00523"
 dependencies = [
  "rand_core",
  "rustcrypto-ff",
@@ -1303,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7535f94fa3339fe9e5e9be6260a909e62af97f6e14b32345ccf79b92b8b81233"
+checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1314,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.6"
+version = "0.11.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1deee7fbcdd62fbcffc9dc2f5f17f96adac881ec7e1506e1eedee1644d0cc535"
+checksum = "c5bfe7820113e633d8886e839aae78c1184b8d7011000db6bc7eb61e34f28350"
 dependencies = [
  "digest",
  "keccak",
@@ -1508,11 +1515,11 @@ dependencies = [
 
 [[package]]
 name = "wasip3"
-version = "0.3.1+wasi-0.3.0-rc-2025-09-16"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba4be47b1d11244670d11857eee0758a8f2c39aea64d80b78c1ce29b4642cd"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen 0.48.1",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1562,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.241.2"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01164c9dda68301e34fdae536c23ed6fe90ce6d97213ccc171eebbd3d02d6b8"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
  "wasmparser",
@@ -1572,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.241.2"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876fe286f2fa416386deedebe8407e6f19e0b5aeaef3d03161e77a15fa80f167"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1584,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.241.2"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d90019b1afd4b808c263e428de644f3003691f243387d30d673211ee0cb8e8"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
@@ -1645,18 +1652,18 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.48.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8c2adb5f74ac9395bc3121c99a1254bf9310482c27b13f97167aedb5887138"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.48.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b881a098cae03686d7a0587f8f306f8a58102ad8da8b5599100fbe0e7f5800b"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck",
@@ -1665,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.48.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69667efa439a453e1d50dac939c6cab6d2c3ac724a9d232b6631dad2472a5b70"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
@@ -1681,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.48.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae2e22cceb5d105d52326c07e3e67603a861cc7add70fc467f7cc7ec5265017"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -1696,9 +1703,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.241.2"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0c57df25e7ee612d946d3b7646c1ddb2310f8280aa2c17e543b66e0812241"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1715,9 +1722,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.241.2"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ef1c6ad67f35c831abd4039c02894de97034100899614d1c44e2268ad01c91"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -14,24 +14,24 @@ keywords = ["crypto", "ecdh", "ecc"]
 readme = "README.md"
 
 [dependencies]
-hkdf = "0.13.0-rc.4"
-kem = "0.3.0-rc.3"
-rand_core = "0.10.0-rc-6"
+hkdf = "0.13.0-rc.5"
+kem = "0.3.0-rc.4"
+rand_core = "0.10"
 
 # optional dependencies
-elliptic-curve = { version = "0.14.0-rc.25", optional = true, default-features = false }
-k256 = { version = "0.14.0-rc.6", optional = true, default-features = false, features = ["arithmetic"] }
-p256 = { version = "0.14.0-rc.6", optional = true, default-features = false, features = ["arithmetic"] }
-p384 = { version = "0.14.0-rc.6", optional = true, default-features = false, features = ["arithmetic"] }
-p521 = { version = "0.14.0-rc.6", optional = true, default-features = false, features = ["arithmetic"] }
+elliptic-curve = { version = "0.14.0-rc.28", optional = true, default-features = false }
+k256 = { version = "0.14.0-rc.7", optional = true, default-features = false, features = ["arithmetic"] }
+p256 = { version = "0.14.0-rc.7", optional = true, default-features = false, features = ["arithmetic"] }
+p384 = { version = "0.14.0-rc.7", optional = true, default-features = false, features = ["arithmetic"] }
+p521 = { version = "0.14.0-rc.7", optional = true, default-features = false, features = ["arithmetic"] }
 x25519 = { version = "=3.0.0-pre.5", package = "x25519-dalek", optional = true, default-features = false }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
-getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
+getrandom = { version = "0.4", features = ["sys_rng"] }
 hex-literal = "1"
-hkdf = "0.13.0-rc.4"
-sha2 = "0.11.0-rc.4"
+hkdf = "0.13.0-rc.5"
+sha2 = "0.11.0-rc.5"
 
 [features]
 default = ["zeroize"]

--- a/dhkem/src/ecdh_kem.rs
+++ b/dhkem/src/ecdh_kem.rs
@@ -5,9 +5,7 @@ use core::marker::PhantomData;
 use elliptic_curve::{
     AffinePoint, CurveArithmetic, Error, FieldBytes, FieldBytesSize, PublicKey, SecretKey,
     ecdh::EphemeralSecret,
-    sec1::{
-        FromEncodedPoint, ModulusSize, ToEncodedPoint, UncompressedPoint, UncompressedPointSize,
-    },
+    sec1::{FromSec1Point, ModulusSize, ToSec1Point, UncompressedPoint, UncompressedPointSize},
 };
 use kem::{
     Ciphertext, Encapsulate, Generate, InvalidKey, Kem, KeyExport, KeySizeUser, SharedKey,
@@ -109,7 +107,7 @@ impl<C> TryDecapsulate<EcdhKem<C>> for EcdhDecapsulationKey<C>
 where
     C: CurveArithmetic,
     FieldBytesSize<C>: ModulusSize,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
 {
     type Error = Error;
 
@@ -154,7 +152,7 @@ impl<C> TryKeyInit for EcdhEncapsulationKey<C>
 where
     C: CurveArithmetic,
     FieldBytesSize<C>: ModulusSize,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
 {
     fn new(encapsulation_key: &UncompressedPoint<C>) -> Result<Self, InvalidKey> {
         PublicKey::<C>::from_sec1_bytes(encapsulation_key)
@@ -175,7 +173,7 @@ impl<C> KeyExport for EcdhEncapsulationKey<C>
 where
     C: CurveArithmetic,
     FieldBytesSize<C>: ModulusSize,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
 {
     fn to_bytes(&self) -> UncompressedPoint<C> {
         self.0.to_uncompressed_point()
@@ -195,7 +193,7 @@ impl<C> Encapsulate<EcdhKem<C>> for EcdhEncapsulationKey<C>
 where
     C: CurveArithmetic,
     FieldBytesSize<C>: ModulusSize,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
 {
     fn encapsulate_with_rng<R>(
         &self,

--- a/dhkem/src/lib.rs
+++ b/dhkem/src/lib.rs
@@ -47,7 +47,7 @@ pub use x25519_kem::{X25519DecapsulationKey, X25519EncapsulationKey, X25519Kem};
 #[cfg(feature = "ecdh")]
 use elliptic_curve::{
     CurveArithmetic, PublicKey, bigint,
-    sec1::{self, FromEncodedPoint, ToEncodedPoint},
+    sec1::{self, FromSec1Point, ToSec1Point},
 };
 
 #[cfg(feature = "zeroize")]
@@ -103,26 +103,26 @@ impl<EK> From<EK> for EncapsulationKey<EK> {
 }
 
 #[cfg(feature = "ecdh")]
-impl<C> FromEncodedPoint<C> for EcdhEncapsulationKey<C>
+impl<C> FromSec1Point<C> for EcdhEncapsulationKey<C>
 where
     C: CurveArithmetic,
     C::FieldBytesSize: sec1::ModulusSize,
-    PublicKey<C>: FromEncodedPoint<C>,
+    PublicKey<C>: FromSec1Point<C>,
 {
-    fn from_encoded_point(point: &sec1::EncodedPoint<C>) -> bigint::CtOption<Self> {
-        PublicKey::<C>::from_encoded_point(point).map(Into::into)
+    fn from_sec1_point(point: &sec1::Sec1Point<C>) -> bigint::CtOption<Self> {
+        PublicKey::<C>::from_sec1_point(point).map(Into::into)
     }
 }
 
 #[cfg(feature = "ecdh")]
-impl<C> ToEncodedPoint<C> for EcdhEncapsulationKey<C>
+impl<C> ToSec1Point<C> for EcdhEncapsulationKey<C>
 where
     C: CurveArithmetic,
     C::FieldBytesSize: sec1::ModulusSize,
-    PublicKey<C>: ToEncodedPoint<C>,
+    PublicKey<C>: ToSec1Point<C>,
 {
-    fn to_encoded_point(&self, compress: bool) -> sec1::EncodedPoint<C> {
-        self.0.to_encoded_point(compress)
+    fn to_sec1_point(&self, compress: bool) -> sec1::Sec1Point<C> {
+        self.0.to_sec1_point(compress)
     }
 }
 

--- a/frodo-kem/Cargo.toml
+++ b/frodo-kem/Cargo.toml
@@ -57,35 +57,35 @@ serde = ["std", "dep:hex", "dep:serde"]
 std = []
 
 [dependencies]
-aes = { version = "0.9.0-rc.2", optional = true }
+aes = { version = "0.9.0-rc.4", optional = true }
 hex = { version = "0.4", optional = true }
 openssl-sys = { version = "0.9.104", optional = true }
-rand_core = { version = "0.10.0-rc-6", features = [] }
+rand_core = { version = "0.10", features = [] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serdect = "0.4"
 subtle = "2.6"
 thiserror = "2.0"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
-sha3 = { version = "0.11.0-rc.3", features = ["asm"] }
+sha3 = { version = "0.11.0-rc.7", features = ["asm"] }
 zeroize = { version = "1", features = ["aarch64"] }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 zeroize = { version = "1", features = ["simd"] }
 
 [target.'cfg(not(target_arch = "aarch64"))'.dependencies]
-sha3 = { version = "0.11.0-rc.0" }
+sha3 = { version = "0.11.0-rc.7" }
 
 [target.'cfg(not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))'.dependencies]
 zeroize = "1"
 
 [dev-dependencies]
-aes = "0.9.0-rc.2"
+aes = "0.9.0-rc.4"
 criterion = "0.7"
 getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
 hex = "0.4"
 hybrid-array = "0.4"
-chacha20 = { version = "0.10.0-rc.9", features = ["rng"] }
+chacha20 = { version = "0.10.0-rc.10", features = ["rng"] }
 rstest = "0.26"
 postcard = { version = "1.0", features = ["use-std"] }
 serde_bare = "0.5"

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -27,9 +27,9 @@ zeroize = ["module-lattice/zeroize", "dep:zeroize"]
 [dependencies]
 array = { version = "0.4.7", package = "hybrid-array", features = ["extra-sizes", "subtle"] }
 module-lattice = { version = "0.1.0-rc.0", features = ["subtle"] }
-kem = "0.3.0-rc.3"
-rand_core = "0.10.0-rc-6"
-sha3 = { version = "0.11.0-rc.6", default-features = false }
+kem = "0.3.0-rc.4"
+rand_core = "0.10"
+sha3 = { version = "0.11.0-rc.7", default-features = false }
 subtle = { version = "2", default-features = false }
 
 # optional dependencies
@@ -39,7 +39,7 @@ zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
+getrandom = { version = "0.4", features = ["sys_rng"] }
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "1"
 num-rational = { version = "0.4.2", default-features = false, features = ["num-bigint"] }

--- a/module-lattice/Cargo.toml
+++ b/module-lattice/Cargo.toml
@@ -24,7 +24,7 @@ subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
-getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
+getrandom = { version = "0.4", features = ["sys_rng"] }
 
 [features]
 subtle = ["dep:subtle", "array/subtle"]

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -19,19 +19,19 @@ zeroize = ["dep:zeroize", "ml-kem/zeroize", "x25519-dalek/zeroize"]
 hazmat = []
 
 [dependencies]
-kem = "0.3.0-rc.3"
+kem = "0.3.0-rc.4"
 ml-kem = { version = "=0.3.0-pre.6", default-features = false, features = ["hazmat"] }
-rand_core = { version = "0.10.0-rc-6", default-features = false }
-sha3 = { version = "0.11.0-rc.6", default-features = false }
+rand_core = { version = "0.10", default-features = false }
+sha3 = { version = "0.11.0-rc.7", default-features = false }
 x25519-dalek = { version = "=3.0.0-pre.5", default-features = false, features = ["static_secrets"] }
 
 # optional dependencies
 zeroize = { version = "1.8.1", optional = true, default-features = true }
 
 [dev-dependencies]
-getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
+getrandom = { version = "0.4", features = ["sys_rng"] }
 hex = { version = "0.4", features = ["serde"] }
-rand_core = "0.10.0-rc-6"
+rand_core = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 


### PR DESCRIPTION
NOTE: bumps `rand_core` to v0.10; `getrandom` to v0.4 (final)

Also updates the following requirements:
- `aes` v0.9.0-rc.4
- `chacha20` v0.10.0-rc.10
- `elliptic-curve` v0.14.0-rc.28
- `hkdf` v0.13.0-rc.5
- `k256` v0.14.0-rc.7
- `kem` v0.3.0-rc.4
- `p256` v0.14.0-rc.7
- `p384` v0.14.0-rc.7
- `p521` v0.14.0-rc.7
- `sha2` v0.11.0-rc.5
- `sha3` v0.11.0-rc.7