### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "dhkem"
-version = "0.1.0-pre.3"
+version = "0.1.0-pre.4"
 dependencies = [
  "elliptic-curve",
  "getrandom",
@@ -465,7 +465,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "frodo-kem"
-version = "0.1.0-pre.2"
+version = "0.1.0-pre.3"
 dependencies = [
  "aes",
  "chacha20",
@@ -774,7 +774,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "ml-kem"
-version = "0.3.0-pre.6"
+version = "0.3.0-pre.7"
 dependencies = [
  "const-oid",
  "criterion",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "module-lattice"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "x-wing"
-version = "0.1.0-pre.6"
+version = "0.1.0-pre.7"
 dependencies = [
  "getrandom",
  "hex",

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of Key Encapsulation Mechanism (KEM) adapters for Elliptic Curve
 Diffie Hellman (ECDH) protocols
 """
-version = "0.1.0-pre.3"
+version = "0.1.0-pre.4"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"

--- a/frodo-kem/Cargo.toml
+++ b/frodo-kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frodo-kem"
-version = "0.1.0-pre.2"
+version = "0.1.0-pre.3"
 description = "Pure Rust implementation of FrodoKEM and eFrodoKEM"
 authors = ["The RustCrypto Team"]
 documentation = "https://docs.rs/frodo-kem"

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Module-Lattice-Based Key-Encapsulation Mechanism Standard
 (formerly known as Kyber) as described in FIPS 203
 """
-version = "0.3.0-pre.6"
+version = "0.3.0-pre.7"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -26,7 +26,7 @@ zeroize = ["module-lattice/zeroize", "dep:zeroize"]
 
 [dependencies]
 array = { version = "0.4.7", package = "hybrid-array", features = ["extra-sizes", "subtle"] }
-module-lattice = { version = "0.1.0-rc.0", features = ["subtle"] }
+module-lattice = { version = "0.1.0-rc.1", features = ["subtle"] }
 kem = "0.3.0-rc.4"
 rand_core = "0.10"
 sha3 = { version = "0.11.0-rc.7", default-features = false }

--- a/module-lattice/Cargo.toml
+++ b/module-lattice/Cargo.toml
@@ -5,7 +5,7 @@ Functionality shared between the `ml-kem` and `ml-dsa` crates, including linear 
 a prime-order field, vectors of such polynomials, and NTT polynomials / vectors, as well as packing of polynomials into
 coefficients with a specified number of bits.
 """
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "x-wing"
 description = "Pure Rust implementation of the X-Wing Key Encapsulation Mechanism (draft 06)"
-version = "0.1.0-pre.6"
+version = "0.1.0-pre.7"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -20,7 +20,7 @@ hazmat = []
 
 [dependencies]
 kem = "0.3.0-rc.4"
-ml-kem = { version = "=0.3.0-pre.6", default-features = false, features = ["hazmat"] }
+ml-kem = { version = "=0.3.0-pre.7", default-features = false, features = ["hazmat"] }
 rand_core = { version = "0.10", default-features = false }
 sha3 = { version = "0.11.0-rc.7", default-features = false }
 x25519-dalek = { version = "=3.0.0-pre.5", default-features = false, features = ["static_secrets"] }


### PR DESCRIPTION
Releases the following with `rand_core` v0.10 and `getrandom` v0.4 dependencies:

- `dhkem` v0.1.0-pre.4
- `frodo-kem` v0.1.0-pre.3
- `ml-kem` v0.3.0-pre.7
- `module-lattice` v0.1.0-rc.1
- `x-wing` v0.1.0-pre.7