### PR TITLE
ml-kem: use `kem::FromSeed` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,8 +732,7 @@ dependencies = [
 [[package]]
 name = "kem"
 version = "0.3.0-rc.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5060d6eb6316d4de23cefe43c3105a2a2f158b5a670a5195de224a796c6afc"
+source = "git+https://github.com/RustCrypto/traits#544e92822f4c59c597d5225dd88f1c064f771c9f"
 dependencies = [
  "crypto-common",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,5 @@ debug = true
 [patch.crates-io]
 ml-kem = { path = "./ml-kem" }
 module-lattice = { path = "./module-lattice" }
+
+kem = { git = "https://github.com/RustCrypto/traits" }

--- a/ml-kem/src/decapsulation_key.rs
+++ b/ml-kem/src/decapsulation_key.rs
@@ -261,21 +261,3 @@ where
         P::concat_dk(dk_pke, ek, self.ek.h(), self.z.clone())
     }
 }
-
-/// Initialize a KEM from a seed.
-pub trait FromSeed: Kem {
-    /// Using the provided [`Seed`] value, create a KEM keypair.
-    fn from_seed(seed: &Seed) -> (Self::DecapsulationKey, Self::EncapsulationKey);
-}
-
-impl<K> FromSeed for K
-where
-    K: Kem,
-    K::DecapsulationKey: KeyInit + KeySizeUser<KeySize = U64>,
-{
-    fn from_seed(seed: &Seed) -> (K::DecapsulationKey, K::EncapsulationKey) {
-        let dk = K::DecapsulationKey::new(seed);
-        let ek = dk.encapsulation_key().clone();
-        (dk, ek)
-    }
-}

--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -69,13 +69,13 @@ mod param;
 pub mod pkcs8;
 
 pub use array::{self, ArraySize};
+pub use decapsulation_key::DecapsulationKey;
 #[allow(deprecated)]
 pub use decapsulation_key::ExpandedKeyEncoding;
-pub use decapsulation_key::{DecapsulationKey, FromSeed};
 pub use encapsulation_key::EncapsulationKey;
 pub use kem::{
-    self, Ciphertext, Decapsulate, Encapsulate, Generate, InvalidKey, Kem, Key, KeyExport, KeyInit,
-    KeySizeUser, TryKeyInit,
+    self, Ciphertext, Decapsulate, Encapsulate, FromSeed, Generate, InvalidKey, Kem, Key,
+    KeyExport, KeyInit, KeySizeUser, TryKeyInit,
 };
 pub use ml_kem_512::MlKem512;
 pub use ml_kem_768::MlKem768;

--- a/ml-kem/tests/key-gen.rs
+++ b/ml-kem/tests/key-gen.rs
@@ -3,7 +3,7 @@
 #![allow(unreachable_pub, reason = "tests")]
 #![allow(clippy::unwrap_used, reason = "tests")]
 
-use array::ArrayN;
+use array::{ArrayN, sizes::U64};
 use core::fmt::Debug;
 use ml_kem::*;
 use std::{fs::read_to_string, path::PathBuf};
@@ -33,7 +33,7 @@ fn acvp_key_gen() {
 #[allow(deprecated)]
 fn verify<K>(tc: &acvp::TestCase)
 where
-    K: Kem + FromSeed,
+    K: Kem + FromSeed<SeedSize = U64>,
     K::DecapsulationKey: ExpandedKeyEncoding + Debug + PartialEq,
     K::EncapsulationKey: KeySizeUser,
 {


### PR DESCRIPTION
The `FromSeed` trait from this crate was upstreamed to the `kem` crate in RustCrypto/traits#2284.

This removes the one in `ml-kem` and re-exports `kem::FromSeed` instead.