### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "dhkem"
-version = "0.1.0-pre.4"
+version = "0.1.0-rc.0"
 dependencies = [
  "elliptic-curve",
  "getrandom",
@@ -774,7 +774,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "ml-kem"
-version = "0.3.0-pre.7"
+version = "0.3.0-rc.0"
 dependencies = [
  "const-oid",
  "criterion",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "x-wing"
-version = "0.1.0-pre.7"
+version = "0.1.0-rc.0"
 dependencies = [
  "getrandom",
  "hex",

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of Key Encapsulation Mechanism (KEM) adapters for Elliptic Curve
 Diffie Hellman (ECDH) protocols
 """
-version = "0.1.0-pre.4"
+version = "0.1.0-rc.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -24,7 +24,7 @@ k256 = { version = "0.14.0-rc.7", optional = true, default-features = false, fea
 p256 = { version = "0.14.0-rc.7", optional = true, default-features = false, features = ["arithmetic"] }
 p384 = { version = "0.14.0-rc.7", optional = true, default-features = false, features = ["arithmetic"] }
 p521 = { version = "0.14.0-rc.7", optional = true, default-features = false, features = ["arithmetic"] }
-x25519 = { version = "=3.0.0-pre.6", package = "x25519-dalek", optional = true, default-features = false }
+x25519 = { version = "3.0.0-pre.6", package = "x25519-dalek", optional = true, default-features = false }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Module-Lattice-Based Key-Encapsulation Mechanism Standard
 (formerly known as Kyber) as described in FIPS 203
 """
-version = "0.3.0-pre.7"
+version = "0.3.0-rc.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "x-wing"
 description = "Pure Rust implementation of the X-Wing Key Encapsulation Mechanism (draft 06)"
-version = "0.1.0-pre.7"
+version = "0.1.0-rc.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -20,10 +20,10 @@ hazmat = []
 
 [dependencies]
 kem = "0.3.0-rc.6"
-ml-kem = { version = "=0.3.0-pre.7", default-features = false, features = ["hazmat"] }
+ml-kem = { version = "0.3.0-rc.0", default-features = false, features = ["hazmat"] }
 rand_core = { version = "0.10", default-features = false }
 sha3 = { version = "0.11.0-rc.7", default-features = false }
-x25519-dalek = { version = "=3.0.0-pre.6", default-features = false, features = ["static_secrets"] }
+x25519-dalek = { version = "3.0.0-pre.6", default-features = false, features = ["static_secrets"] }
 
 # optional dependencies
 zeroize = { version = "1.8.1", optional = true, default-features = true }


### PR DESCRIPTION
Releases the following, which hopefully have a now finalized `kem` crate API implemenetation:

- `dhkem` v0.1.0-rc.0
- `ml-kem` v0.3.0-rc.0
- `x-wing` v0.1.0-rc.0

Their versions have all been bumped to `rc.0` accordingly