### PR TITLE
frodo-kem: fix OpenSSL EVP contexts memory leak

### DIFF
--- a/frodo-kem/src/hazmat/models.rs
+++ b/frodo-kem/src/hazmat/models.rs
@@ -987,6 +987,7 @@ impl<P: Params> Expanded for FrodoAes<P> {
             {
                 panic!("EVP_EncryptInit_ex failed");
             }
+            openssl_sys::EVP_CIPHER_CTX_free(aes_key_schedule);
         }
         #[cfg(target_endian = "big")]
         {
@@ -1114,6 +1115,7 @@ impl<P: Params> Expanded for FrodoShake<P> {
                 {
                     panic!("EVP_DigestFinalXOF failed");
                 }
+                openssl_sys::EVP_MD_CTX_free(shake);
             }
         }
         #[cfg(target_endian = "big")]


### PR DESCRIPTION
When using OpenSSL, objects allocated during matrix generation are never freed, leaking memory on every keygen, encapsulation, and decapsulation. 

Can verify the memory leak (on macOS) using: 

```bash
cargo test -p frodo-kem --features openssl --no-run 2>&1 | grep -o 'frodo_kem-[^ )]*' | head -1 | xargs -I{} sh -c 'MallocStackLogging=1 leaks --atExit -- target/debug/deps/{}'
```

With output:

```
<TRUNCATED>
7   frodo_kem-4b28b6bdda7d5aed            0x104d06a8c frodo_kem::Algorithm::inner_generate_keypair::h75a46a4868372de8 + 60  lib.rs:1358
6   frodo_kem-4b28b6bdda7d5aed            0x104d4357c frodo_kem::hazmat::traits::Kem::generate_keypair::ha8b1217d1779d0cb + 1064  traits.rs:162
5   frodo_kem-4b28b6bdda7d5aed            0x104d39624 _$LT$frodo_kem..hazmat..models..EphemeralFrodoKem$LT$P$C$E$C$S$GT$$u20$as$u20$frodo_kem..hazmat..traits..Expanded$GT$::expand_a::h2acb9f402f18b5b8 + 76  models.rs:626
4   frodo_kem-4b28b6bdda7d5aed            0x104d3a75c _$LT$frodo_kem..hazmat..models..FrodoAes$LT$P$GT$$u20$as$u20$frodo_kem..hazmat..traits..Expanded$GT$::expand_a::h949973832bb22364 + 684  models.rs:966
3   libcrypto.3.dylib                     0x105a27040 EVP_CIPHER_CTX_new + 28
2   libcrypto.3.dylib                     0x105b6887c CRYPTO_zalloc + 20
1   libcrypto.3.dylib                     0x105b68820 CRYPTO_malloc + 112
0   libsystem_malloc.dylib                0x19bba10f4 _malloc_zone_malloc_instrumented_or_legacy + 268 
====
    2 (640 bytes) ROOT LEAK: <malloc in CRYPTO_malloc 0x6000010b8540> [192]
       1 (448 bytes) <malloc in CRYPTO_malloc 0x14d98c8a0> [448]
<TRUNCATED>
```