### PR TITLE
frodo-kem: remove `ct_eq_bytes` method

### DIFF
--- a/frodo-kem/src/lib.rs
+++ b/frodo-kem/src/lib.rs
@@ -236,7 +236,7 @@ macro_rules! ct_eq_imp {
     ($name:ident) => {
         impl ConstantTimeEq for $name {
             fn ct_eq(&self, other: &Self) -> Choice {
-                self.algorithm.ct_eq(&other.algorithm) & ct_eq_bytes(&self.value, &other.value)
+                self.algorithm.ct_eq(&other.algorithm) & self.value.ct_eq(&other.value)
             }
         }
 
@@ -1642,20 +1642,6 @@ pub struct AlgorithmParams {
     pub decryption_key_length: usize,
     /// The byte length of the ciphertext
     pub ciphertext_length: usize,
-}
-
-fn ct_eq_bytes(lhs: &[u8], rhs: &[u8]) -> Choice {
-    if lhs.len() != rhs.len() {
-        return 0u8.into();
-    }
-
-    let mut eq = 0u8;
-    for i in 0..lhs.len() {
-        eq |= lhs[i] ^ rhs[i];
-    }
-
-    let eq = ((eq | eq.wrapping_neg()) >> 7).wrapping_add(1);
-    Choice::from(eq)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Feel free to just pick the fix commit, in case you don't want the regression test.

The test fails with:

```
---- tests::ct_eq_bytes_produces_valid_choice stdout ----

thread 'tests::ct_eq_bytes_produces_valid_choice' panicked at /Users/rot256/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/subtle-2.6.1/src/lib.rs:239:9:
assertion failed: (input == 0u8) | (input == 1u8)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
