### PR TITLE
ml-kem v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "ml-kem"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "criterion",
  "crypto-common",

--- a/ml-kem/CHANGELOG.md
+++ b/ml-kem/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.3 (2026-02-17)
+### Fixed
+- Use `doc_cfg` instead of `doc_auto_cfg` ([#265])
+
+[#265]: https://github.com/RustCrypto/KEMs/pull/265
+
 ## 0.2.2 (2026-01-24)
+### Changed
 - Pin `kem` crate dependency to `=0.3.0-pre.0` ([#194])
 
 [#194]: https://github.com/RustCrypto/KEMs/pull/194

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Module-Lattice-Based Key-Encapsulation Mechanism Standard
 (formerly known as Kyber) as described in FIPS 203
 """
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0 OR MIT"

--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",


### PR DESCRIPTION
### Fixed
- Use `doc_cfg` instead of `doc_auto_cfg` ([#265])

[#265]: https://github.com/RustCrypto/KEMs/pull/265