### PR TITLE
module-lattice v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "module-lattice"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ctutils",
  "getrandom",

--- a/module-lattice/CHANGELOG.md
+++ b/module-lattice/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2026-04-03)
+### Added
+- Impl `ctutils::CtEq` for `Polynomial`, `Vector`, and `NttMatrix` ([#285])
+
+[#285]: https://github.com/RustCrypto/KEMs/pull/285
+
 ## 0.2.0 (2026-03-26)
 ### Changed
 - Migrate from `subtle` to `ctutils` ([#277])

--- a/module-lattice/Cargo.toml
+++ b/module-lattice/Cargo.toml
@@ -5,7 +5,7 @@ Functionality shared between the `ml-kem` and `ml-dsa` crates, including linear 
 degree-256 polynomials over a prime-order field, vectors of such polynomials, and NTT polynomials
 and vectors, as well as packing of polynomials into coefficients with a specified number of bits
 """
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
## Added
- Impl `ctutils::CtEq` for `Polynomial`, `Vector`, and `NttMatrix` ([#285])

[#285]: https://github.com/RustCrypto/KEMs/pull/285