### PR TITLE
ml-kem: bump `pkcs8` dependency to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,9 +936,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.12"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d71d6da5a0e652b5c694049095a52f5e564012b8ee5001cf10d84a4ca9a7f9d"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "spki",

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -33,7 +33,7 @@ sha3 = { version = "0.11", default-features = false }
 
 # optional dependencies
 const-oid = { version = "0.10.1", optional = true, default-features = false, features = ["db"] }
-pkcs8 = { version = "0.11.0-rc.12", optional = true, default-features = false }
+pkcs8 = { version = "0.11", optional = true, default-features = false }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Release PR: RustCrypto/formats#2314