### PR TITLE
module-lattice v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "module-lattice"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ctutils",
  "getrandom",

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -26,7 +26,7 @@ zeroize = ["module-lattice/zeroize", "dep:zeroize"]
 
 [dependencies]
 array = { version = "0.4.8", package = "hybrid-array", features = ["ctutils", "extra-sizes"] }
-module-lattice = { version = "0.2", features = ["ctutils"] }
+module-lattice = { version = "0.2.2", features = ["ctutils"] }
 kem = "0.3"
 rand_core = "0.10"
 sha3 = { version = "0.11", default-features = false }

--- a/module-lattice/CHANGELOG.md
+++ b/module-lattice/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2 (2026-04-28)
+### Fixed
+- Avoid UDIV in compiled output on ARM targets ([#289])
+
+[#289]: https://github.com/RustCrypto/KEMs/pull/289
+
 ## 0.2.1 (2026-04-03)
 ### Added
 - Impl `ctutils::CtEq` for `Polynomial`, `Vector`, and `NttMatrix` ([#285])

--- a/module-lattice/Cargo.toml
+++ b/module-lattice/Cargo.toml
@@ -5,7 +5,7 @@ Functionality shared between the `ml-kem` and `ml-dsa` crates, including linear 
 degree-256 polynomials over a prime-order field, vectors of such polynomials, and NTT polynomials
 and vectors, as well as packing of polynomials into coefficients with a specified number of bits
 """
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
## Fixed
- Avoid UDIV in compiled output on ARM targets ([#289])

[#289]: https://github.com/RustCrypto/KEMs/pull/289