### PR TITLE
ml-kem v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "module-lattice"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ctutils",
  "getrandom",

--- a/ml-kem/CHANGELOG.md
+++ b/ml-kem/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 (2026-05-10)
+### Added
+- Optional on-by-default heap offload support ([#310])
+
+[#310]: https://github.com/RustCrypto/KEMs/pull/310
+
 ## 0.3.0 (2026-04-28)
 ### Added
 - `Seed` support e.g. `DecapsulationKey::from_seed` ([#133], [#138])

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["crypto", "kyber", "lattice", "post-quantum"]
 exclude = ["tests/key-gen.rs", "tests/key-gen.json", "tests/encap-decap.rs", "tests/encap-decap.json"]
 
 [features]
+default = ["alloc"]
 alloc = ["module-lattice/alloc", "pkcs8?/alloc"]
 
 getrandom = ["kem/getrandom"]


### PR DESCRIPTION
### Added
- Optional on-by-default heap offload support ([#310])

[#310]: https://github.com/RustCrypto/KEMs/pull/310