### PR TITLE
ml-kem v0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,7 +786,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "ml-kem"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "const-oid",
  "criterion",

--- a/ml-kem/CHANGELOG.md
+++ b/ml-kem/CHANGELOG.md
@@ -5,11 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.1 (2026-05-10)
+## 0.3.2 (2026-05-10)
 ### Added
 - Optional on-by-default heap offload support ([#310])
 
 [#310]: https://github.com/RustCrypto/KEMs/pull/310
+
+## 0.3.1
+Skipped as it was tagged without a version bump.
 
 ## 0.3.0 (2026-04-28)
 ### Added

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Module-Lattice-Based Key-Encapsulation Mechanism Standard
 (formerly known as Kyber) as described in FIPS 203
 """
-version = "0.3.0"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
## Added
- Optional on-by-default heap offload support ([#310])

[#310]: https://github.com/RustCrypto/KEMs/pull/310