### PR TITLE
ml-kem: fix build on Rust 1.96

### DIFF
--- a/ml-kem/src/algebra.rs
+++ b/ml-kem/src/algebra.rs
@@ -119,6 +119,7 @@ where
     Eta: CbdSamplingSize,
     K: ArraySize,
 {
+    #[allow(unstable_name_collisions, reason = "TODO")]
     Vector::new(Array::from_fn(|i| {
         let N = start_n + u8::truncate(i);
         let prf_output = PRF::<Eta>(sigma, N);

--- a/ml-kem/src/compress.rs
+++ b/ml-kem/src/compress.rs
@@ -35,6 +35,7 @@ impl Compress for Elem {
     //
     //   round(a / b) = floor((a + b/2) / b)
     //   a / q ~= (a * x) >> s where x >> s ~= 1/q
+    #[allow(unstable_name_collisions, reason = "TODO")]
     fn compress<D: CompressionFactor>(&mut self) -> &Self {
         const Q_HALF: u64 = (BaseField::QLL + 1) >> 1;
         let x = u64::from(self.0);


### PR DESCRIPTION
It seems `u*::truncate` has been reserved for future use in `core`, so we will need to eventually phase out the related functionality in the `module-lattice` crate.

For now this adds `allow(unstable_name_collisions)`.