### PR TITLE
Bump `sha3` to v0.12; use `shake` v0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -75,15 +75,6 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
@@ -133,7 +124,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core",
 ]
 
@@ -170,8 +161,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.2",
+ "block-buffer",
+ "crypto-common",
  "inout",
 ]
 
@@ -226,15 +217,6 @@ name = "cpubits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -332,16 +314,6 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -368,7 +340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "curve25519-dalek-derive",
  "fiat-crypto",
  "rustc_version",
@@ -419,23 +391,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
 ]
 
@@ -453,8 +415,8 @@ checksum = "102d3643d30dd8b559613c5cced68317199597fffb278cdc88daa2ef7fafc935"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "crypto-common 0.2.2",
- "digest 0.11.3",
+ "crypto-common",
+ "digest",
  "ff",
  "group",
  "hkdf",
@@ -531,7 +493,8 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serdect",
- "sha3 0.11.0",
+ "sha3",
+ "shake",
  "subtle",
  "thiserror",
  "toml",
@@ -578,16 +541,6 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -712,7 +665,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -728,7 +681,8 @@ dependencies = [
  "rand",
  "serde",
  "serdect",
- "sha3 0.10.9",
+ "sha3",
+ "shake",
  "subtle",
  "thiserror",
  "typenum",
@@ -813,21 +767,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
-dependencies = [
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "keccak"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -836,7 +781,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "rand_core",
 ]
 
@@ -890,7 +835,8 @@ dependencies = [
  "rand_core",
  "serde",
  "serde_json",
- "sha3 0.11.0",
+ "sha3",
+ "shake",
  "zeroize",
 ]
 
@@ -1092,7 +1038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f845ec3240cd5ed5e1e31cf3ff633a5bf47c698dc4092ba9e767415b3d393406"
 dependencies = [
  "crypto-bigint",
- "crypto-common 0.2.2",
+ "crypto-common",
  "ff",
  "rand_core",
  "subtle",
@@ -1399,28 +1345,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.9"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
 dependencies = [
- "digest 0.10.7",
- "keccak 0.1.6",
+ "digest",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
-name = "sha3"
-version = "0.11.0"
+name = "shake"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
 dependencies = [
- "digest 0.11.3",
- "keccak 0.2.0",
+ "digest",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -1453,6 +1401,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1587,12 +1541,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1849,7 +1797,8 @@ dependencies = [
  "rand_core",
  "serde",
  "serde_json",
- "sha3 0.11.0",
+ "sha3",
+ "shake",
  "x25519-dalek",
  "zeroize",
 ]

--- a/frodo-kem/Cargo.toml
+++ b/frodo-kem/Cargo.toml
@@ -63,7 +63,8 @@ openssl-sys = { version = "0.9.104", optional = true }
 rand_core = { version = "0.10", features = [] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serdect = "0.4"
-sha3 = "0.11"
+sha3 = "0.12"
+shake = "0.1"
 subtle = "2.6"
 thiserror = "2.0"
 zeroize = "1"

--- a/frodo-kem/src/hazmat/models.rs
+++ b/frodo-kem/src/hazmat/models.rs
@@ -686,7 +686,7 @@ pub struct Frodo640;
 
 #[cfg(any(feature = "frodo640aes", feature = "frodo640shake",))]
 impl Params for Frodo640 {
-    type Shake = sha3::Shake128;
+    type Shake = shake::Shake128;
 
     const CDF_TABLE: &'static [u16] = InnerFrodo640::CDF_TABLE;
     const CLAIMED_NIST_LEVEL: usize = InnerFrodo640::CLAIMED_NIST_LEVEL;
@@ -704,7 +704,7 @@ pub struct EphemeralFrodo640;
 
 #[cfg(any(feature = "efrodo640aes", feature = "efrodo640shake",))]
 impl Params for EphemeralFrodo640 {
-    type Shake = sha3::Shake128;
+    type Shake = shake::Shake128;
 
     const BYTES_SALT: usize = 0;
     const BYTES_SEED_SE: usize = Self::SHARED_SECRET_LENGTH;
@@ -749,7 +749,7 @@ pub struct Frodo976;
 
 #[cfg(any(feature = "frodo976aes", feature = "frodo976shake",))]
 impl Params for Frodo976 {
-    type Shake = sha3::Shake256;
+    type Shake = shake::Shake256;
 
     const CDF_TABLE: &'static [u16] = InnerFrodo976::CDF_TABLE;
     const CLAIMED_NIST_LEVEL: usize = InnerFrodo976::CLAIMED_NIST_LEVEL;
@@ -767,7 +767,7 @@ pub struct EphemeralFrodo976;
 
 #[cfg(any(feature = "efrodo976aes", feature = "efrodo976shake",))]
 impl Params for EphemeralFrodo976 {
-    type Shake = sha3::Shake256;
+    type Shake = shake::Shake256;
 
     const BYTES_SALT: usize = 0;
     const BYTES_SEED_SE: usize = InnerFrodo976::SHARED_SECRET_LENGTH;
@@ -810,7 +810,7 @@ pub struct Frodo1344;
 
 #[cfg(any(feature = "frodo1344aes", feature = "frodo1344shake",))]
 impl Params for Frodo1344 {
-    type Shake = sha3::Shake256;
+    type Shake = shake::Shake256;
 
     const CDF_TABLE: &'static [u16] = InnerFrodo1344::CDF_TABLE;
     const CLAIMED_NIST_LEVEL: usize = InnerFrodo1344::CLAIMED_NIST_LEVEL;
@@ -828,7 +828,7 @@ pub struct EphemeralFrodo1344;
 
 #[cfg(any(feature = "efrodo1344aes", feature = "efrodo1344shake",))]
 impl Params for EphemeralFrodo1344 {
-    type Shake = sha3::Shake256;
+    type Shake = shake::Shake256;
 
     const BYTES_SALT: usize = 0;
     const BYTES_SEED_SE: usize = Self::SHARED_SECRET_LENGTH;
@@ -1028,7 +1028,7 @@ impl<P: Params> Expanded for FrodoShake<P> {
     const METHOD: &'static str = "SHAKE";
 
     fn expand_a(&self, seed_a: &[u8], a: &mut [u16]) {
-        use sha3::{
+        use shake::{
             Shake128,
             digest::{ExtendableOutputReset, Update},
         };

--- a/frodo-kem/src/hazmat/models.rs
+++ b/frodo-kem/src/hazmat/models.rs
@@ -1028,10 +1028,7 @@ impl<P: Params> Expanded for FrodoShake<P> {
     const METHOD: &'static str = "SHAKE";
 
     fn expand_a(&self, seed_a: &[u8], a: &mut [u16]) {
-        use shake::{
-            Shake128,
-            digest::{ExtendableOutputReset, Update},
-        };
+        use shake::{Shake128, Update, digest::ExtendableOutputReset};
 
         debug_assert_eq!(a.len(), P::N_X_N);
         debug_assert_eq!(seed_a.len(), P::BYTES_SEED_A);

--- a/hqc-kem/Cargo.toml
+++ b/hqc-kem/Cargo.toml
@@ -28,7 +28,8 @@ hybrid-array = { version = "0.4.10", optional = true, features = ["extra-sizes"]
 kem_traits = { package = "kem", version = "0.3.0-rc.6", optional = true }
 pkcs8 = { version = "0.11", optional = true, default-features = false }
 rand = "0.10"
-sha3 = "0.10"
+sha3 = { version = "0.12", default-features = false }
+shake = { version = "0.1", default-features = false }
 serdect = { version = "0.4", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 subtle = "2"

--- a/hqc-kem/src/shake.rs
+++ b/hqc-kem/src/shake.rs
@@ -7,10 +7,7 @@
 //! - 0x03: J function (SHA3-256, rejection key)
 
 use sha3::{Digest, Sha3_256, Sha3_512};
-use shake::{
-    Shake256,
-    digest::{ExtendableOutput, Update, XofReader},
-};
+use shake::{ExtendableOutput, Shake256, Update, XofReader};
 
 /// Domain separation bytes.
 pub(crate) const DOMAIN_G: u8 = 0x00;

--- a/hqc-kem/src/shake.rs
+++ b/hqc-kem/src/shake.rs
@@ -1,12 +1,16 @@
-/// SHAKE256-based seed expander and domain-separated hash functions.
-///
-/// v5.0.0 domain bytes:
-/// - 0x00: G function (SHA3-512), KAT PRNG
-/// - 0x01: H function (SHA3-256), XOF seed expander
-/// - 0x02: I function (SHA3-512, PKE keygen)
-/// - 0x03: J function (SHA3-256, rejection key)
-use sha3::digest::{ExtendableOutput, Update, XofReader};
-use sha3::{Digest, Sha3_256, Sha3_512, Shake256};
+//! SHAKE256-based seed expander and domain-separated hash functions.
+//!
+//! v5.0.0 domain bytes:
+//! - 0x00: G function (SHA3-512), KAT PRNG
+//! - 0x01: H function (SHA3-256), XOF seed expander
+//! - 0x02: I function (SHA3-512, PKE keygen)
+//! - 0x03: J function (SHA3-256, rejection key)
+
+use sha3::{Digest, Sha3_256, Sha3_512};
+use shake::{
+    Shake256,
+    digest::{ExtendableOutput, Update, XofReader},
+};
 
 /// Domain separation bytes.
 pub(crate) const DOMAIN_G: u8 = 0x00;

--- a/hqc-kem/tests/kat.rs
+++ b/hqc-kem/tests/kat.rs
@@ -9,13 +9,13 @@ use hqc_kem::{hqc128, hqc192, hqc256};
 /// KAT PRNG: wraps the internal SHAKE256-based PRNG.
 /// Implements rand TryRng + TryCryptoRng (rand 0.10) for use with the API.
 struct KatRng {
-    reader: sha3::digest::core_api::XofReaderCoreWrapper<sha3::Shake256ReaderCore>,
+    reader: shake::Shake256Reader,
 }
 
 impl KatRng {
     fn new(seed: &[u8]) -> Self {
-        use sha3::digest::{ExtendableOutput, Update};
-        let mut hasher = sha3::Shake256::default();
+        use shake::digest::{ExtendableOutput, Update};
+        let mut hasher = shake::Shake256::default();
         hasher.update(seed);
         hasher.update(&[0x00]); // KAT PRNG domain byte
         Self {
@@ -40,7 +40,7 @@ impl rand::TryRng for KatRng {
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
-        use sha3::digest::XofReader;
+        use shake::digest::XofReader;
         self.reader.read(dest);
         Ok(())
     }

--- a/hqc-kem/tests/kat.rs
+++ b/hqc-kem/tests/kat.rs
@@ -14,7 +14,7 @@ struct KatRng {
 
 impl KatRng {
     fn new(seed: &[u8]) -> Self {
-        use shake::digest::{ExtendableOutput, Update};
+        use shake::{ExtendableOutput, Update};
         let mut hasher = shake::Shake256::default();
         hasher.update(seed);
         hasher.update(&[0x00]); // KAT PRNG domain byte
@@ -40,7 +40,7 @@ impl rand::TryRng for KatRng {
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
-        use shake::digest::XofReader;
+        use shake::XofReader;
         self.reader.read(dest);
         Ok(())
     }

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -30,7 +30,8 @@ array = { version = "0.4.8", package = "hybrid-array", features = ["ctutils", "e
 module-lattice = { version = "0.2.3", features = ["ctutils"] }
 kem = "0.3"
 rand_core = "0.10"
-sha3 = { version = "0.11", default-features = false }
+sha3 = { version = "0.12", default-features = false }
+shake = { version = "0.1", default-features = false }
 
 # optional dependencies
 const-oid = { version = "0.10.1", optional = true, default-features = false, features = ["db"] }

--- a/ml-kem/src/crypto.rs
+++ b/ml-kem/src/crypto.rs
@@ -3,10 +3,7 @@
 use crate::{B32, param::CbdSamplingSize};
 use module_lattice::EncodedPolynomial;
 use sha3::{Sha3_256, Sha3_512, digest::Digest};
-use shake::{
-    Shake128, Shake256,
-    digest::{ExtendableOutput, Update, XofReader},
-};
+use shake::{ExtendableOutput, Shake128, Shake256, Update, XofReader};
 
 pub(crate) fn G(inputs: &[impl AsRef<[u8]>]) -> (B32, B32) {
     let mut h = Sha3_512::new();

--- a/ml-kem/src/crypto.rs
+++ b/ml-kem/src/crypto.rs
@@ -2,8 +2,9 @@
 
 use crate::{B32, param::CbdSamplingSize};
 use module_lattice::EncodedPolynomial;
-use sha3::{
-    Digest, Sha3_256, Sha3_512, Shake128, Shake256,
+use sha3::{Sha3_256, Sha3_512, digest::Digest};
+use shake::{
+    Shake128, Shake256,
     digest::{ExtendableOutput, Update, XofReader},
 };
 

--- a/ml-kem/src/crypto.rs
+++ b/ml-kem/src/crypto.rs
@@ -2,7 +2,7 @@
 
 use crate::{B32, param::CbdSamplingSize};
 use module_lattice::EncodedPolynomial;
-use sha3::{Sha3_256, Sha3_512, digest::Digest};
+use sha3::{Digest, Sha3_256, Sha3_512};
 use shake::{ExtendableOutput, Shake128, Shake256, Update, XofReader};
 
 pub(crate) fn G(inputs: &[impl AsRef<[u8]>]) -> (B32, B32) {

--- a/x-wing/Cargo.toml
+++ b/x-wing/Cargo.toml
@@ -22,7 +22,8 @@ hazmat = []
 kem = "0.3"
 ml-kem = { version = "0.3.0-rc.0", default-features = false, features = ["hazmat"] }
 rand_core = { version = "0.10", default-features = false }
-sha3 = { version = "0.11", default-features = false }
+sha3 = { version = "0.12", default-features = false }
+shake = { version = "0.1", default-features = false }
 x25519-dalek = { version = "3.0.0-pre.6", default-features = false, features = ["static_secrets"] }
 
 # optional dependencies

--- a/x-wing/src/lib.rs
+++ b/x-wing/src/lib.rs
@@ -42,10 +42,7 @@ use ml_kem::{
 };
 use rand_core::{CryptoRng, TryCryptoRng, TryRng};
 use sha3::Sha3_256;
-use shake::{
-    Shake256, Shake256Reader,
-    digest::{ExtendableOutput, XofReader},
-};
+use shake::{ExtendableOutput, Shake256, Shake256Reader, XofReader};
 use x25519_dalek::{PublicKey, StaticSecret};
 
 #[cfg(feature = "zeroize")]

--- a/x-wing/src/lib.rs
+++ b/x-wing/src/lib.rs
@@ -41,8 +41,9 @@ use ml_kem::{
     ml_kem_768,
 };
 use rand_core::{CryptoRng, TryCryptoRng, TryRng};
-use sha3::{
-    Sha3_256, Shake256, Shake256Reader,
+use sha3::Sha3_256;
+use shake::{
+    Shake256, Shake256Reader,
     digest::{ExtendableOutput, XofReader},
 };
 use x25519_dalek::{PublicKey, StaticSecret};


### PR DESCRIPTION
The v0.12 release of `sha3` split `shake` into its own crate.