### PR TITLE
Support HPKE DHKEM suite IDs

### DIFF
--- a/dhkem/src/expander.rs
+++ b/dhkem/src/expander.rs
@@ -12,17 +12,34 @@ const PREFIXES_MAX: usize = 256;
 /// Maximum size of input key material or info after applying prefixes.
 const LABELED_INPUT_MAX: usize = PREFIXES_MAX + 64;
 
-/// HPKE version identifier from `RFC9810 §4`.
+/// HPKE version identifier from `RFC9180 §4`.
 const HPKE_VERSION_ID: &[u8] = b"HPKE-v1";
 
-/// HPKE suite ID from `RFC9810 §4`.
-const HPKE_SUITE_ID: &[u8] = b"KEM\x00\x10";
+/// HPKE KEM identifier for DHKEM(P-256, HKDF-SHA256).
+///
+/// Assigned by RFC 9180, Section 7.1, Table 2.
+pub const HPKE_DHKEM_P256_HKDF_SHA256_KEM_ID: u16 = 0x0010;
+
+/// HPKE KEM identifier for DHKEM(P-384, HKDF-SHA384).
+///
+/// Assigned by RFC 9180, Section 7.1, Table 2.
+pub const HPKE_DHKEM_P384_HKDF_SHA384_KEM_ID: u16 = 0x0011;
+
+/// HPKE KEM identifier for DHKEM(P-521, HKDF-SHA512).
+///
+/// Assigned by RFC 9180, Section 7.1, Table 2.
+pub const HPKE_DHKEM_P521_HKDF_SHA512_KEM_ID: u16 = 0x0012;
+
+/// HPKE KEM identifier for DHKEM(X25519, HKDF-SHA256).
+///
+/// Assigned by RFC 9180, Section 7.1, Table 2.
+pub const HPKE_DHKEM_X25519_HKDF_SHA256_KEM_ID: u16 = 0x0020;
 
 /// Expander: wrapper for [RFC5869] HKDF-Expand operation which can be used for HPKE's
-/// `LabeledExtract` and `LabeledExpand` as described in [RFC9810 §4].
+/// `LabeledExtract` and `LabeledExpand` as described in [RFC9180 §4].
 ///
 /// [RFC5869]: https://datatracker.ietf.org/doc/html/rfc5869
-/// [RFC9810 §4]: https://datatracker.ietf.org/doc/html/rfc9180#section-4
+/// [RFC9180 §4]: https://datatracker.ietf.org/doc/html/rfc9180#section-4
 #[derive(Debug)]
 pub struct Expander<D: EagerHash> {
     /// Inner HKDF instance
@@ -64,21 +81,43 @@ impl<D: EagerHash> Expander<D> {
         Ok(ret)
     }
 
-    /// Create a new expander which uses the prefixes that implement HPKE `LabeledExtract` as
-    /// described in [RFC9810 §4].
+    /// Create a new expander which uses the prefixes that implement HPKE `LabeledExtract` for
+    /// DHKEM(P-256, HKDF-SHA256) as described in [RFC9180 §4].
     ///
     /// # Errors
     /// Returns [`InvalidLength`] if the concatenated prefixes are too long.
     ///
-    /// [RFC9810 §4]: https://datatracker.ietf.org/doc/html/rfc9180#section-4
+    /// [RFC9180 §4]: https://datatracker.ietf.org/doc/html/rfc9180#section-4
     pub fn new_labeled_hpke(
         salt: &[u8],
         label: &[u8],
         input_key_material: &[u8],
     ) -> Result<Self, InvalidLength> {
+        Self::new_labeled_hpke_with_kem_id(
+            HPKE_DHKEM_P256_HKDF_SHA256_KEM_ID,
+            salt,
+            label,
+            input_key_material,
+        )
+    }
+
+    /// Create a new expander which uses the prefixes that implement HPKE `LabeledExtract` as
+    /// described in [RFC9180 §4].
+    ///
+    /// # Errors
+    /// Returns [`InvalidLength`] if the concatenated prefixes are too long.
+    ///
+    /// [RFC9180 §4]: https://datatracker.ietf.org/doc/html/rfc9180#section-4
+    pub fn new_labeled_hpke_with_kem_id(
+        kem_id: u16,
+        salt: &[u8],
+        label: &[u8],
+        input_key_material: &[u8],
+    ) -> Result<Self, InvalidLength> {
+        let suite_id = hpke_kem_suite_id(kem_id);
         Self::new_prefixed(
             salt,
-            &[HPKE_VERSION_ID, HPKE_SUITE_ID, label],
+            &[HPKE_VERSION_ID, &suite_id, label],
             input_key_material,
         )
     }
@@ -92,7 +131,7 @@ impl<D: EagerHash> Expander<D> {
     /// Returns [`InvalidLength`] if info is too long.
     ///
     /// [RFC5869]: https://datatracker.ietf.org/doc/html/rfc5869
-    /// [RFC9810 §4]: https://datatracker.ietf.org/doc/html/rfc9180#section-4
+    /// [RFC9180 §4]: https://datatracker.ietf.org/doc/html/rfc9180#section-4
     pub fn expand(&self, info: &[u8], okm: &mut [u8]) -> Result<(), InvalidLength> {
         self.hkdf.expand(info, okm)
     }
@@ -114,31 +153,54 @@ impl<D: EagerHash> Expander<D> {
         self.hkdf.expand_multi_info(info_components, okm)
     }
 
-    /// Create a new expander which uses the prefixes that implement HPKE `LabeledExpand` as
-    /// described in [RFC9810 §4].
+    /// Perform HPKE `LabeledExpand` for DHKEM(P-256, HKDF-SHA256) as described in [RFC9180 §4].
     ///
     /// # Errors
     /// Returns [`InvalidLength`] if label and/or info is too long.
     ///
-    /// [RFC9810 §4]: https://datatracker.ietf.org/doc/html/rfc9180#section-4
+    /// [RFC9180 §4]: https://datatracker.ietf.org/doc/html/rfc9180#section-4
     pub fn expand_labeled_hpke(
         &self,
         label: &[u8],
         info: &[u8],
         okm: &mut [u8],
     ) -> Result<(), InvalidLength> {
+        self.expand_labeled_hpke_with_kem_id(HPKE_DHKEM_P256_HKDF_SHA256_KEM_ID, label, info, okm)
+    }
+
+    /// Perform HPKE `LabeledExpand` as described in [RFC9180 §4].
+    ///
+    /// # Errors
+    /// Returns [`InvalidLength`] if label and/or info is too long.
+    ///
+    /// [RFC9180 §4]: https://datatracker.ietf.org/doc/html/rfc9180#section-4
+    pub fn expand_labeled_hpke_with_kem_id(
+        &self,
+        kem_id: u16,
+        label: &[u8],
+        info: &[u8],
+        okm: &mut [u8],
+    ) -> Result<(), InvalidLength> {
         let okm_len = u16::try_from(okm.len()).map_err(|_| InvalidLength)?;
+        let suite_id = hpke_kem_suite_id(kem_id);
         self.hkdf.expand_multi_info(
             &[
                 &okm_len.to_be_bytes(),
                 HPKE_VERSION_ID,
-                HPKE_SUITE_ID,
+                &suite_id,
                 label,
                 info,
             ],
             okm,
         )
     }
+}
+
+/// Build the DHKEM suite ID used by HPKE `LabeledExtract` and `LabeledExpand`:
+/// `"KEM" || I2OSP(kem_id, 2)`.
+fn hpke_kem_suite_id(kem_id: u16) -> [u8; 5] {
+    let kem_id = kem_id.to_be_bytes();
+    [b'K', b'E', b'M', kem_id[0], kem_id[1]]
 }
 
 fn concat_slices<'a, I>(slices: I, out: &mut [u8]) -> Result<&[u8], InvalidLength>

--- a/dhkem/src/lib.rs
+++ b/dhkem/src/lib.rs
@@ -31,7 +31,10 @@
 
 mod expander;
 
-pub use expander::{Expander, InvalidLength};
+pub use expander::{
+    Expander, HPKE_DHKEM_P256_HKDF_SHA256_KEM_ID, HPKE_DHKEM_P384_HKDF_SHA384_KEM_ID,
+    HPKE_DHKEM_P521_HKDF_SHA512_KEM_ID, HPKE_DHKEM_X25519_HKDF_SHA256_KEM_ID, InvalidLength,
+};
 pub use kem::{self, Decapsulator, Encapsulate, Generate, Kem, TryDecapsulate};
 
 #[cfg(feature = "ecdh")]

--- a/dhkem/tests/hpke_x25519_test.rs
+++ b/dhkem/tests/hpke_x25519_test.rs
@@ -1,0 +1,51 @@
+//! HPKE X25519 tests.
+
+#![cfg(feature = "x25519")]
+#![allow(clippy::unwrap_used, reason = "tests")]
+
+use dhkem::{HPKE_DHKEM_X25519_HKDF_SHA256_KEM_ID, X25519DecapsulationKey};
+use hex_literal::hex;
+use kem::{Decapsulate, Key, KeyInit};
+use sha2::Sha256;
+
+type Expander = dhkem::Expander<Sha256>;
+
+fn extract_and_expand(shared_secret: &[u8], kem_context: &[u8]) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    let expander = Expander::new_labeled_hpke_with_kem_id(
+        HPKE_DHKEM_X25519_HKDF_SHA256_KEM_ID,
+        b"",
+        b"eae_prk",
+        shared_secret,
+    )
+    .unwrap();
+    expander
+        .expand_labeled_hpke_with_kem_id(
+            HPKE_DHKEM_X25519_HKDF_SHA256_KEM_ID,
+            b"shared_secret",
+            kem_context,
+            &mut out,
+        )
+        .unwrap();
+
+    out
+}
+
+#[test]
+// RFC 9180 appendix A.7.1
+fn test_dhkem_x25519_hkdf_sha256_export_only() {
+    let recipient_secret = Key::<X25519DecapsulationKey>::from(hex!(
+        "33d196c830a12f9ac65d6e565a590d80f04ee9b19c83c87f2c170d972a812848"
+    ));
+    let recipient_public = hex!("194141ca6c3c3beb4792cd97ba0ea1faff09d98435012345766ee33aae2d7664");
+    let encapsulated = hex!("e5e8f9bfff6c2f29791fc351d2c25ce1299aa5eaca78a757c0b4fb4bcd830918");
+    let expected_shared_secret =
+        hex!("e81716ce8f73141d4f25ee9098efc968c91e5b8ce52ffff59d64039e82918b66");
+
+    let skr = X25519DecapsulationKey::new(&recipient_secret);
+    let raw_shared_secret = skr.decapsulate(&encapsulated.into());
+    let kem_context = [encapsulated.as_slice(), recipient_public.as_slice()].concat();
+
+    let shared_secret = extract_and_expand(&raw_shared_secret, &kem_context);
+    assert_eq!(shared_secret, expected_shared_secret);
+}


### PR DESCRIPTION
This fixes HPKE labeled extract/expand support for non-P-256 DHKEMs.

The existing `Expander::new_labeled_hpke` and
`Expander::expand_labeled_hpke` helpers always use suite ID `KEM\x00\x10`,
which is DHKEM(P-256, HKDF-SHA256). That is correct for P-256, but not
for other DHKEMs exposed by the crate.

This adds KEM-ID-aware helper methods and public KEM ID constants, while
leaving the existing helpers as P-256-compatible wrappers. The regression
test covers the RFC 9180 X25519 export-only vector.

Verification:

```text
cargo test -p dhkem --features x25519 test_dhkem_x25519_hkdf_sha256_export_only
```

-----
This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The vulnerability was identified primarily by the Codex coding agent, and manually reviewed before submission.
