### PR TITLE
dhkem: bump `k256`/`p256`/`p384`/`p521` to v0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,9 +397,9 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3273f1195b6f6253ebda493d6742c8baa9b26a291674cd96d92a0f09e90e9b46"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.14"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "905d38bdbb43bb506efa0a428b3e969ff244549832a86b18591492f503adfe37"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
  "cpubits",
  "elliptic-curve",
@@ -864,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.14"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c855a8d2ffd346aa03122626f22e96e3aa75e3bfe64e6bf6cb82f71821ed6ae7"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "elliptic-curve",
  "primefield",
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.14"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941b68907ddf996ac20f0debf700c236ccc3d874637731a93c631129ca042f"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
 dependencies = [
  "elliptic-curve",
  "fiat-crypto",
@@ -887,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.14"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd6f2fe6e76c8d5e8828e92aafa463777d1e72e70b78acc724214757e92479a"
+checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
 dependencies = [
  "base16ct",
  "elliptic-curve",
@@ -985,12 +985,13 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.14"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e56e6d67fdf5744e9e245ae571450fe584b91f5af261d0e40163b618e53a1f6"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
  "primefield",
+ "wnaf",
 ]
 
 [[package]]
@@ -1575,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "wnaf"
-version = "0.14.0-rc.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86421f2a70c9e6cab8d84c99fb62d8761d355bd1285443a7e7ccad15aa515f2"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
 dependencies = [
  "ff",
  "group",

--- a/dhkem/Cargo.toml
+++ b/dhkem/Cargo.toml
@@ -20,10 +20,10 @@ rand_core = "0.10"
 
 # optional dependencies
 elliptic-curve = { version = "0.14", optional = true, default-features = false }
-k256 = { version = "0.14.0-rc.14", optional = true, default-features = false, features = ["arithmetic"] }
-p256 = { version = "0.14.0-rc.14", optional = true, default-features = false, features = ["arithmetic"] }
-p384 = { version = "0.14.0-rc.14", optional = true, default-features = false, features = ["arithmetic"] }
-p521 = { version = "0.14.0-rc.14", optional = true, default-features = false, features = ["arithmetic"] }
+k256 = { version = "0.14", optional = true, default-features = false, features = ["arithmetic"] }
+p256 = { version = "0.14", optional = true, default-features = false, features = ["arithmetic"] }
+p384 = { version = "0.14", optional = true, default-features = false, features = ["arithmetic"] }
+p521 = { version = "0.14", optional = true, default-features = false, features = ["arithmetic"] }
 x25519 = { version = "3", package = "x25519-dalek", optional = true, default-features = false }
 zeroize = { version = "1.9", optional = true, default-features = false }
 


### PR DESCRIPTION
Release PRs:
- `k256` v0.14.0: RustCrypto/elliptic-curves#1900
- `p256` v0.14.0: RustCrypto/elliptic-curves#1890
- `p384` v0.14.0: RustCrypto/elliptic-curves#1892
- `p521` v0.14.0: RustCrypto/elliptic-curves#1902